### PR TITLE
AI generated: Add Jekyll build actions

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -1,0 +1,28 @@
+name: Jekyll Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+
+    - name: Install dependencies
+      run: bundle install
+
+    - name: Build Jekyll site
+      run: bundle exec jekyll build

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 title: software-architektur.tv 
 tagline: Software Architektur im Stream
 url: https://software-architektur.tv 
+baseurl: ""
 
 author:
   name: Eberhard Wolff


### PR DESCRIPTION
Fixes #36

Add GitHub Actions workflow for Jekyll build

* Create `.github/workflows/jekyll-build.yml` to configure Jekyll build actions
* Add steps to check out the repository, set up Ruby, install dependencies, and build the Jekyll site
* Trigger workflow on push and pull request events for the `main` branch
* Update `_config.yml` to ensure compatibility with the Jekyll build actions by adding `baseurl` setting

Note: this PR was generated by githup copilot workspaces

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ewolff/software-architektur.tv/pull/37?shareId=91290ea2-d2d8-455f-affd-fbe67a37c15e).