### PR TITLE
Add date for Death Star architecture talk (July 11, 2025) - Clean Version

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -6,9 +6,11 @@ description: Überblick über die geplanten Folgen
 
 # Planung
 
-|      Datum | Thema / Gäste                                                                           |
-|-----------:|:----------------------------------------------------------------------------------------|
+|      Datum | Thema / Gäste                                                                              |
+|-----------:|:-------------------------------------------------------------------------------------------|
 | 2025-07-04 | Open-Source-Komponenten richtig im Projekt oder Produkt verwenden mit Prof. Dirk Riehle |
+| 2025-07-11 | The Architecture of the Death Start with Juan G. Carmona                                 |
 | 2025-08-01 | Model Context Protocol (MCP): Schnittstellen für LLMs schaffen mit Martin Lippert       |
-| 2025-10-17 | Wardley Maps mit Markus Harrer                                                          |
+| 2025-09-12 | ? mit Gernot Starke                                                                    |
+| 2025-10-17 | Wardley Maps mit Markus Harrer                                                         |
 


### PR DESCRIPTION
This PR adds the date for the Death Star architecture talk with Juan G. Carmona.

## Changes
- Added date `2025-07-11` for "The Architecture of the Death Start with Juan G. Carmona"
- Ordered entries chronologically
- Fixed encoding issues and synced with current upstream

## Context
The Death Star talk was previously scheduled without a specific date. This PR sets the date to July 11th, 2025 as requested.

This is a clean version that should not have any merge conflicts.

Co-authored-by: Claude (AI Assistant)