### PR TITLE
Add guest/moderator metadata: Episodes 263-254 (Batch 2/10)

### DIFF
--- a/_posts/2025-03-14-folge254.md
+++ b/_posts/2025-03-14-folge254.md
@@ -12,6 +12,10 @@ tags:
 - Communication Patterns
 - Kommunikation
 - Agile Meets Architecture
+guests:
+  - "Jacqui Read"
+moderators:
+  - "Eberhard Wolff"
 ---
 
 In this episode Jacqui Read is our guest. She is the author of the

--- a/_posts/2025-03-18-episode255.md
+++ b/_posts/2025-03-18-episode255.md
@@ -11,6 +11,11 @@ tags:
 - English
 - Agile meet Architecture
 - Kommunikation
+guests:
+  - "Cosima Laube"
+  - "Sofia Katsaouni"
+moderators:
+  - "Eberhard Wolff"
 ---
 
 In the fast-paced world of software development and architecture,

--- a/_posts/2025-03-21-folge256.md
+++ b/_posts/2025-03-21-folge256.md
@@ -11,6 +11,8 @@ tags:
 - Organisation
 - Grundlagen
 - Kommunikation
+moderators:
+  - "Eberhard Wolff"
 ---
 
 Projekte erstellen gemeinsame Software. Irgendwie müssen

--- a/_posts/2025-03-28-folge257.md
+++ b/_posts/2025-03-28-folge257.md
@@ -9,6 +9,8 @@ description: Warum sollte man heute noch Monolithen zu Microservices migrieren -
 thumbnail: folge257.png
 tags:
 - Microservices
+moderators:
+  - "Eberhard Wolff"
 ---
 
 Microservices waren einst ein regelrechter Hype, insbesondere weil man

--- a/_posts/2025-04-03-episode258.md
+++ b/_posts/2025-04-03-episode258.md
@@ -11,6 +11,8 @@ tags:
 - English
 - Wardley Maps
 - Agile Meets Architecture
+moderators:
+  - "Eberhard Wolff"
 ---
 
 In this episode, Simon Wardley, together with Carola Lilienthal,

--- a/_posts/2025-04-04-episode259.md
+++ b/_posts/2025-04-04-episode259.md
@@ -11,6 +11,11 @@ tags:
 - English
 - Organisation
 - Agile Meets Architecture
+guests:
+  - "Ana Nad"
+  - "Lejla Vulovic"
+moderators:
+  - "Eberhard Wolff"
 ---
 
 Join us as we sit down with Ana Nad and Lejla Vulovic after their talk

--- a/_posts/2025-04-11-episode260.md
+++ b/_posts/2025-04-11-episode260.md
@@ -9,6 +9,8 @@ description: Ein Paper argumentiert, KI sei Bullshit - was bedeutet das für uns
 thumbnail: folge260.png
 tags:
 - Künstliche Intelligenz
+moderators:
+  - "Eberhard Wolff"
 ---
 
 Ein wissenschaftliches Paper argumentiert, dass ChatGPT „Bullshit“

--- a/_posts/2025-04-25-folge261.md
+++ b/_posts/2025-04-25-folge261.md
@@ -10,6 +10,8 @@ thumbnail: folge261.png
 tags:
 - Bounded Context
 - Domain-driven Design
+moderators:
+  - "Eberhard Wolff"
 ---
 
 Bounded Contexts werden oft als Allheilmittel für die fachliche

--- a/_posts/2025-05-02-episode262.md
+++ b/_posts/2025-05-02-episode262.md
@@ -11,6 +11,8 @@ tags:
 - English
 - Agile Meets Architecture
 - Q&A
+moderators:
+  - "Eberhard Wolff"
 ---
 
 I recently spoke at the Agile Meets Architecture conference about

--- a/_posts/2025-05-16-folge263.md
+++ b/_posts/2025-05-16-folge263.md
@@ -10,6 +10,11 @@ thumbnail: folge263.png
 tags:
 - Agilität
 - Postagilität
+guests:
+  - "Tanja Friedel"
+  - "Uwe Vigenschow"
+moderators:
+  - "Eberhard Wolff"
 ---
 
 Der Begriff „Agilität“ ist in den letzten 20 Jahren für alles Mögliche


### PR DESCRIPTION
## Guest-List Feature Implementation - Batch 2/10

This PR adds `guests:` and `moderators:` frontmatter metadata to episodes 263-254 (next 10 episodes).

### Changes Made
- Added YAML arrays for guests and moderators in frontmatter  
- Used full names as requested in Issue #60
- Separate fields for guests vs moderators

### Episode Details
**Episodes with Guests:**
- **Episode 263**: Tanja Friedel, Uwe Vigenschow (guests) - Postagilität theme
- **Episode 259**: Ana Nad, Lejla Vulovic (guests) - Building Product Teams
- **Episode 255**: Cosima Laube, Sofia Katsaouni (guests) - Mind Skills for Change  
- **Episode 254**: Jacqui Read (guest) - Communication Patterns

**Moderator-only Episodes:**
- **Episodes 262,261,260,258,257,256**: Eberhard Wolff (moderator, thematic discussions)

### Progress
- ✅ **Batch 1**: Episodes 273-264 (PR #61)
- ✅ **Batch 2**: Episodes 263-254 (this PR)
- 🔄 **Next**: Episodes 253-244 (Batch 3)
- Target: Complete all 271 episodes in ~10 PRs total

Relates to #60