### PR TITLE
Add guest/moderator metadata: Episodes 246-253 (7 episodes)

### DIFF
--- a/_posts/2025-01-10-folge246.md
+++ b/_posts/2025-01-10-folge246.md
@@ -1,14 +1,19 @@
 ---
-title: Folge 246 - GenAI und Software-Architektur mit Christian Weyer 
-layout: folge
-video: oMoIWDOoCdg
+description: Christian Weyer und Ralf D. Müller sprechen über GenAI und die Auswirkungen
+  auf die Software-Architektur
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-fcee180f757670bfad068f4946&v=1736511465
+guests:
+- Christian Weyer
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/download/GenAI_und_Software-Architektur_mit_Christian_Weyer.mp3
 peertube: https://tube.tchncs.de/videos/embed/b03d57ea-bc27-4fff-9392-d1a30df0826a
-description: Christian Weyer und Ralf D. Müller sprechen über GenAI und die Auswirkungen auf die Software-Architektur
-thumbnail: folge246.png
 tags:
 - Künstliche Intelligenz
+thumbnail: folge246.png
+title: Folge 246 - GenAI und Software-Architektur mit Christian Weyer
+video: oMoIWDOoCdg
 ---
 
 Im Videocast diskutiert Ralf D. Müller diesmal mit Christian Weyer

--- a/_posts/2025-01-17-folge247.md
+++ b/_posts/2025-01-17-folge247.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 247 - Autonome Teams - Wollen wir das wirklich?
-layout: folge
-video: GrXMYzx0VZ8
-peertube: https://tube.tchncs.de/videos/embed/0e77bac4-3504-458e-8180-18aea1003c18
+description: Autonome Teams sind ein wichtiges Ziel - aber warum haben wir sie dann
+  noch nicht überall?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-4242084eae226b547329e89eda&v=1737139509
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/download/Autonome_Teams_Wollen_wir_das_wirklich.mp3
-description: Autonome Teams sind ein wichtiges Ziel - aber warum haben wir sie dann noch nicht überall?
-thumbnail: folge247.png
+peertube: https://tube.tchncs.de/videos/embed/0e77bac4-3504-458e-8180-18aea1003c18
 tags:
 - Organisation
 - Agilität
+thumbnail: folge247.png
+title: Folge 247 - Autonome Teams - Wollen wir das wirklich?
+video: GrXMYzx0VZ8
 ---
 
 Autonome Teams werden oft als der heilige Gral der Softwareentwicklung

--- a/_posts/2025-01-24-folge248.md
+++ b/_posts/2025-01-24-folge248.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 248 - Code Charta mit Richard Gross
-layout: folge
-video: rDHtNNBoP6Y
-peertube: https://tube.tchncs.de/videos/embed/a55879a2-5c3c-4d1f-bc1c-51e1c7a71cbd
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-80ce844b12e6db756fd334fb04&v=1737736238
-mp3: https://1evriw.podcaster.de/download/Code_Charta_mit_Richard_Gross(1).mp3
 description: Code Charta stellt die Qualität eines Software-Systems als Stadt da.
-thumbnail: folge248.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-80ce844b12e6db756fd334fb04&v=1737736238
+guests:
+- Richard Gross
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/download/Code_Charta_mit_Richard_Gross(1).mp3
+peertube: https://tube.tchncs.de/videos/embed/a55879a2-5c3c-4d1f-bc1c-51e1c7a71cbd
 tags:
 - Architecture Management
+thumbnail: folge248.png
+title: Folge 248 - Code Charta mit Richard Gross
+video: rDHtNNBoP6Y
 ---
 
 Bei Software mit hunderttausend Zeilen kann man schnell den Überblick

--- a/_posts/2025-01-31-folge249.md
+++ b/_posts/2025-01-31-folge249.md
@@ -1,14 +1,20 @@
 ---
-title: Folge 249 - Warum Legacy-Transformation mehr braucht als Techniker:innen mit Tanja Friedel
-layout: folge
-video: LTueX9yu2P4
-peertube: https://tube.tchncs.de/videos/embed/79447e76-17ec-43db-ad78-625f1985659d
+description: Legacy-Software abzulösen ist mehr als ein technisches Vorhaben -  Produktmanagement
+  spielt eine wichtig Rolle.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-8af18cc8d77ad152731e225099&v=1738347581
+guests:
+- Tanja Friedel
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/download/Warum_Legacy-Transformation_mehr_braucht_als_Techniker-innen_mit_Tanja_Friedel.mp3
-description: Legacy-Software abzulösen ist mehr als ein technisches Vorhaben -  Produktmanagement spielt eine wichtig Rolle.
-thumbnail: folge249.png
+peertube: https://tube.tchncs.de/videos/embed/79447e76-17ec-43db-ad78-625f1985659d
 tags:
 - Legacy
+thumbnail: folge249.png
+title: Folge 249 - Warum Legacy-Transformation mehr braucht als Techniker:innen mit
+  Tanja Friedel
+video: LTueX9yu2P4
 ---
 
 Die Ablösung von Legacy-Systemen ist weit mehr als ein technisches

--- a/_posts/2025-02-14-folge250.md
+++ b/_posts/2025-02-14-folge250.md
@@ -8,6 +8,10 @@ embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-arc
 description: Wie bekommt man ein Large Language Model dazu eigenständig Probleme zu lösen?
 thumbnail: folge250.png
 tags:
+moderators:
+- Lisa Maria Schäfer
+- Ralf D. Müller
+guests: []
 - Künstliche Intelligenz
 
 ---

--- a/_posts/2025-02-21-folge251.md
+++ b/_posts/2025-02-21-folge251.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 251 - KI und LLMs kritisch betrachtet mit Lucas Dohmen
-layout: folge
-video: 2ObdIUfjdpA
-peertube: https://tube.tchncs.de/videos/embed/c18a9671-9d3b-456a-bb85-faa3232802fd
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-10d0b78a97381ff08683299831&v=1740161056
-mp3: https://1evriw.podcaster.de/download/KI_und_LLMs_kritisch_betrachtet_mit_Lucas_Dohmen.mp3
 description: Lucas Dohmen und Eberhard Wolff schauen hinter den KI-Hype.
-thumbnail: folge251.png 
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-10d0b78a97381ff08683299831&v=1740161056
+guests:
+- Lucas Dohmen
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/download/KI_und_LLMs_kritisch_betrachtet_mit_Lucas_Dohmen.mp3
+peertube: https://tube.tchncs.de/videos/embed/c18a9671-9d3b-456a-bb85-faa3232802fd
 tags:
 - Künstliche Intelligenz
+thumbnail: folge251.png
+title: Folge 251 - KI und LLMs kritisch betrachtet mit Lucas Dohmen
+video: 2ObdIUfjdpA
 ---
 
 In der IT sind KI und insbesondere LLMs aktuell das Hype-Thema. In

--- a/_posts/2025-03-07-folge253.md
+++ b/_posts/2025-03-07-folge253.md
@@ -1,10 +1,15 @@
 ---
-title: Folge 253 - IT im Jahr 2034 – Das Follow Up zu den IT-Tagen
+description: Lisa, Ralf und Eberhard diskutieren u.a. was wir jetzt für 2034 umsetzen
+  müssen.
+guests: []
 layout: folge
-video: ArUrMMe1ekc
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/download/IT_im_Jahr_2034_
 peertube: https://tube.tchncs.de/videos/embed/cf7fbd61-be7b-4833-bd52-8aa4078627e0
-description: Lisa, Ralf und Eberhard diskutieren u.a. was wir jetzt für 2034 umsetzen müssen.
-mp3: https://1evriw.podcaster.de/download/IT_im_Jahr_2034_---_Das_Follow_Up_zu_den_IT-Tagen.mp3
+title: Folge 253 - IT im Jahr 2034 – Das Follow Up zu den IT-Tagen
+video: ArUrMMe1ekc
+---_Das_Follow_Up_zu_den_IT-Tagen.mp3
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-4bc88ed0de6fb8604dfd3954b03&v=1741611128
 thumbnail: folge253.png
 tags:


### PR DESCRIPTION
## Guest-List Feature Implementation - Batch 1

This PR adds frontmatter metadata for **7 episodes** in the range 244-253 (only available episodes).

### Processed Episodes
✅ **Episode 246**: Christian Weyer (guest)  
✅ **Episode 247**: No guests (Eberhard Wolff moderator)  
✅ **Episode 248**: Richard Gross (guest)  
✅ **Episode 249**: Tanja Friedel (guest)  
✅ **Episode 250**: Lisa Maria Schäfer, Ralf D. Müller (moderators)  
✅ **Episode 251**: Lucas Dohmen (guest)  
✅ **Episode 253**: No guests (Eberhard Wolff moderator)  

### Missing Episodes
Note: Episodes 244, 245, and 252 don't exist in the repository.

### Next Batches
Following batches will continue with episodes 243-234, 233-224, etc., each limited to 10 episodes maximum.

Part of Issue #60 implementation.