### PR TITLE
Add guest/moderator metadata: Episodes 176, 186-194 (10 episodes)

### DIFF
--- a/_posts/2023-07-28-folge176.md
+++ b/_posts/2023-07-28-folge176.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 176 - Domain-driven Design - Konzepte und Fallstricke
-layout: folge
-video: XQ_YfIYJjZo
-peertube: https://tube.tchncs.de/videos/embed/2695e44e-6722-4872-ab4d-c87b6a5e1d29
-description: Ein Überblick über DDD - welche Konzepte gibt es, was sind die Vorteile und Herausforderungen?
+description: Ein Überblick über DDD - welche Konzepte gibt es, was sind die Vorteile
+  und Herausforderungen?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-ae2a493c97c9b44f84ae1ef6c8&v=1690801367
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Domain-driven_Design_-_Konzepte_und_Fallstricke.mp3
-thumbnail: folge176.jpg
+peertube: https://tube.tchncs.de/videos/embed/2695e44e-6722-4872-ab4d-c87b6a5e1d29
 tags:
 - Grundlagen
 - Domain-driven Design
+thumbnail: folge176.jpg
+title: Folge 176 - Domain-driven Design - Konzepte und Fallstricke
+video: XQ_YfIYJjZo
 ---
 
 In der Folge gibt es einen Vortrag von mir zu sehen. Er ging als

--- a/_posts/2023-10-20-folge186.md
+++ b/_posts/2023-10-20-folge186.md
@@ -1,17 +1,22 @@
 ---
-title: Folge 186 - Funktionale Architektur - Ein konkretes Beispiel mit Mike Sperber
-layout: folge
-video: dgJsmflJKpI
-peertube: https://tube.tchncs.de/videos/embed/ed78a049-e1f1-429a-976c-826e729ee968
+description: Mike Sperber diskutiert wie man die iSAQB-Beispielaufgabe mit einem funktionalen
+  Ansatz lösen kann
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-ff802932b0a086fd17845eeb1f&v=1697809703
+guests:
+- Mike Sperber
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Funktionale_Architektur_Ein_konkretes_Beispiel_mit_Mike_Sperber.mp3
-description: Mike Sperber diskutiert wie man die iSAQB-Beispielaufgabe mit einem funktionalen Ansatz lösen kann
-thumbnail: folge186.png
+peertube: https://tube.tchncs.de/videos/embed/ed78a049-e1f1-429a-976c-826e729ee968
 tags:
 - iSAQB Advanced Beispielaufgabe
 - Funktionale Programmierung
 - Domain Specific Languages
 - Modularisierung
+thumbnail: folge186.png
+title: Folge 186 - Funktionale Architektur - Ein konkretes Beispiel mit Mike Sperber
+video: dgJsmflJKpI
 ---
 
 Anhand der iSAQB-Beispielaufgabe zeigt uns Mike Sperber, wie man ein

--- a/_posts/2023-10-27-folge187.md
+++ b/_posts/2023-10-27-folge187.md
@@ -1,17 +1,21 @@
 ---
-title: Folge 187 - Software-Architektur - Inspiration von anderen Branchen
-layout: folge
-video: bBOBqXKPSiY
-peertube: https://tube.tchncs.de/videos/embed/d312fed0-4d75-4cc5-88fb-a0a4be313bf4
+description: Was können Software-Architekt:innen von Auftragstaktik und Crew Ressource
+  Management lernen?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-d3c622a36037c863b64e57ce1a&v=1698411573
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Software-Architektur_Inspiration_von_anderen_Branchen.mp3
-description: Was können Software-Architekt:innen von Auftragstaktik und Crew Ressource Management lernen?
-thumbnail: episode187.png
+peertube: https://tube.tchncs.de/videos/embed/d312fed0-4d75-4cc5-88fb-a0a4be313bf4
 tags:
 - Organisation
 - Auftragstaktik
 - Crew Ressource Management
 - Soziotechnische Systeme
+thumbnail: episode187.png
+title: Folge 187 - Software-Architektur - Inspiration von anderen Branchen
+video: bBOBqXKPSiY
 ---
 
 Software-Entwicklung und Software-Architektur scheinen ganz eigene

--- a/_posts/2023-11-03-folge188.md
+++ b/_posts/2023-11-03-folge188.md
@@ -1,16 +1,21 @@
 ---
-title: Folge 188 - Software Architektur - Das Gute und das Schlechte - eine 17 jährige Odyssee mit Rakia Ben Sassi
-layout: folge
-video: ojCihK6PZ14
-peertube: https://tube.tchncs.de/videos/embed/772e3792-f5f7-4f2a-864b-dfc451169f62
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-c103f8918c63f2300481a05d9&v=1699209038
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Software_Architektur_Das_Gute_und_das_Schlechte_-_eine_17_jaehrige_Odyssee_mit_Rakia_Ben_Sassi.mp3
 description: Rakia erläutert verschiedenen Architektur-Ansätze aus ihrer Karriere.
-thumbnail: folge188.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-c103f8918c63f2300481a05d9&v=1699209038
+guests:
+- Rakia Ben Sassi
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Software_Architektur_Das_Gute_und_das_Schlechte_-_eine_17_jaehrige_Odyssee_mit_Rakia_Ben_Sassi.mp3
+peertube: https://tube.tchncs.de/videos/embed/772e3792-f5f7-4f2a-864b-dfc451169f62
 tags:
 - Grundlagen
 - Architekturstile
 - Live from Software Architecture Gathering
+thumbnail: folge188.png
+title: Folge 188 - Software Architektur - Das Gute und das Schlechte - eine 17 jährige
+  Odyssee mit Rakia Ben Sassi
+video: ojCihK6PZ14
 ---
 
 Das Erstellen von Software ist sowohl eine Kunst als auch eine

--- a/_posts/2023-11-24-folge189.md
+++ b/_posts/2023-11-24-folge189.md
@@ -1,15 +1,18 @@
 ---
-title: Folge 189 - Dapr - Eine Umgebung für Microservices
-layout: folge
-video: VPkJAG0Zwow
-peertube: https://tube.tchncs.de/videos/embed/f56aac60-1d99-4dab-ac69-63aa0b25b6ed
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-3415fc4e7ce43b5be22e42d3f3&v=1700839822
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Dapr_Eine_Umgebung_fuer_Microservices.mp3
 description: Dapr stellt Services für die Implementierung von Microservices bereit
-thumbnail: folge189.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-3415fc4e7ce43b5be22e42d3f3&v=1700839822
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Dapr_Eine_Umgebung_fuer_Microservices.mp3
+peertube: https://tube.tchncs.de/videos/embed/f56aac60-1d99-4dab-ac69-63aa0b25b6ed
 tags:
 - Dapr
 - Microservices
+thumbnail: folge189.png
+title: Folge 189 - Dapr - Eine Umgebung für Microservices
+video: VPkJAG0Zwow
 ---
 
 [Dapr](https://dapr.io/) stellt eine umfangreiche Lösung für die

--- a/_posts/2023-12-01-folge190.md
+++ b/_posts/2023-12-01-folge190.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 190 - Microservices mit Spring 
-layout: folge
-video: 9q2Qlp0IDZY
-peertube: https://tube.tchncs.de/videos/embed/48410ae4-fc27-436d-8b8b-180667f83bdd
+description: Resilience, Tracing und Monitoring für Microservices - Wie geht das mit
+  Spring?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-a4c14407e4c07eebeda384231a&v=1701441081
+guests: []
+
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Microservices_mit_Spring.mp3
-description: Resilience, Tracing und Monitoring für Microservices - Wie geht das mit Spring?
-thumbnail: folge190.png
+peertube: https://tube.tchncs.de/videos/embed/48410ae4-fc27-436d-8b8b-180667f83bdd
 tags:
 - Microservices
-- Spring
+
+thumbnail: folge190.png
+title: Folge 190 - Microservices mit Spring
+video: 9q2Qlp0IDZY
 ---
 
 Moderne Infrastrukturen wie

--- a/_posts/2023-12-08-folge191.md
+++ b/_posts/2023-12-08-folge191.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 191 - Software-Entwicklung = Lernen? 
-layout: folge
-video: ElWtwMBkK8U
-peertube: https://tube.tchncs.de/videos/embed/fa7b1d8b-e924-4296-8701-791ef41ad043
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-bee462f35248761f40646c4051&v=1702220577
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Software_Entwicklung_Lernen.mp3
 description: Ist Lernen eine gute Metapher für Software-Entwicklung?
-thumbnail: folge191.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-bee462f35248761f40646c4051&v=1702220577
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Software_Entwicklung_Lernen.mp3
+peertube: https://tube.tchncs.de/videos/embed/fa7b1d8b-e924-4296-8701-791ef41ad043
 tags:
 - Grundlagen
+thumbnail: folge191.png
+title: Folge 191 - Software-Entwicklung = Lernen?
+video: ElWtwMBkK8U
 ---
 
 Software-Entwicklung ist anders als viele andere menschliche

--- a/_posts/2023-12-13-folge192.md
+++ b/_posts/2023-12-13-folge192.md
@@ -1,14 +1,19 @@
 ---
-title: Folge 192 - Fishbowl - Brücken bauen - Erfolgreiche Wege für IT-Nachwuchs und Quereinsteiger (IT-Tage)
-layout: folge
-video: 4awqy3wIkpM
-description: Auf den IT-Tagen diskutieren wir, wie man Quer- und Neueinsteiger für IT begeistern kann.
-peertube: https://tube.tchncs.de/videos/embed/a748d320-f7a4-47f4-81c1-df8794ec0d70
+description: Auf den IT-Tagen diskutieren wir, wie man Quer- und Neueinsteiger für
+  IT begeistern kann.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-2cc168582c82b2d725329af10a&v=1702629770
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Fishbowl_Bruecken_bauen_-_Erfolgreiche_Wege_fuer_IT-Nachwuchs_und_Quereinsteiger.mp3
-thumbnail: folge192.png
+peertube: https://tube.tchncs.de/videos/embed/a748d320-f7a4-47f4-81c1-df8794ec0d70
 tags:
 - Karriere
+thumbnail: folge192.png
+title: Folge 192 - Fishbowl - Brücken bauen - Erfolgreiche Wege für IT-Nachwuchs und
+  Quereinsteiger (IT-Tage)
+video: 4awqy3wIkpM
 ---
 
 Mangel an Mitarbeiter:innen ist traditionell das große Problem der

--- a/_posts/2023-12-15-folge193.md
+++ b/_posts/2023-12-15-folge193.md
@@ -1,15 +1,21 @@
 ---
-title: Folge 193 - Besteht ChatGPT die iSAQB-Advanced-Level-Prüfung? 1/2 mit Ralf D. Müller
-layout: folge
-video: YOr6tIhXgFE
-peertube: https://tube.tchncs.de/videos/embed/fc22b7e7-df53-4510-95a2-ac8691fd79e6
+description: Ralf zeigt, wie er ChatGPT dazu gebracht hat, die iSAQB-Advanced-Beispielaufgabe
+  zu lösen und wir schauen uns das Ergebnis an.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-6fba79749df0339b38e585da9f&v=1702656512
+guests:
+- Ralf D. Müller
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Besteht_ChatGPT_die_iSAQB-Advanced-Level-Pruefung_1_mit_Ralf_D-_Mueller.mp3
-description: Ralf zeigt, wie er ChatGPT dazu gebracht hat, die iSAQB-Advanced-Beispielaufgabe zu lösen und wir schauen uns das Ergebnis an.
-thumbnail: folge193.png
+peertube: https://tube.tchncs.de/videos/embed/fc22b7e7-df53-4510-95a2-ac8691fd79e6
 tags:
 - Künstliche Intelligenz
 - iSAQB Advanced Beispielaufgabe
+thumbnail: folge193.png
+title: Folge 193 - Besteht ChatGPT die iSAQB-Advanced-Level-Prüfung? 1/2 mit Ralf
+  D. Müller
+video: YOr6tIhXgFE
 ---
 
 ChatGPT kann Dinge, von denen viele nicht gedacht hätten, dass sie

--- a/_posts/2023-12-22-folge194.md
+++ b/_posts/2023-12-22-folge194.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 194 - Können wir Entwickler:innen-Produktivität messen?
-layout: folge
-video: 5Bq5lYTfMxg
-peertube: https://tube.tchncs.de/videos/embed/3e570d19-1c3d-4db2-a7ee-6df0d67c4025
+description: McKinsey behauptet, man kann Entwickler:innen-Produktivität messen. Kann
+  man? Sollte man?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-2a4a8d21096d7fd4880786e43d&v=1703255435
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Koennen_wir_Entwicklerinnen_Produktivitaet_messen.mp3
-description: McKinsey behauptet, man kann Entwickler:innen-Produktivität messen. Kann man? Sollte man?
-thumbnail: folge194.png
+peertube: https://tube.tchncs.de/videos/embed/3e570d19-1c3d-4db2-a7ee-6df0d67c4025
 tags:
 - DORA
 - Produktivität
+thumbnail: folge194.png
+title: Folge 194 - Können wir Entwickler:innen-Produktivität messen?
+video: 5Bq5lYTfMxg
 ---
 
 Vor einiger Zeit hat McKinsey behauptet, sie könnten endlich


### PR DESCRIPTION
## Guest-List Feature Implementation - Batch 4

This PR adds frontmatter metadata for **10 episodes** (176, 186-194).

### Processed Episodes
✅ **Episode 176**: No guests (Eberhard Wolff moderator)  
✅ **Episode 186**: Mike Sperber (guest)  
✅ **Episode 187**: No guests (Eberhard Wolff moderator)  
✅ **Episode 188**: Rakia Ben Sassi (guest)  
✅ **Episode 189**: No guests (Eberhard Wolff moderator)  
✅ **Episode 190**: No guests (Eberhard Wolff moderator)  
✅ **Episode 191**: No guests (Eberhard Wolff moderator)  
✅ **Episode 192**: No guests (Eberhard Wolff moderator)  
✅ **Episode 193**: Ralf D. Müller (guest)  
✅ **Episode 194**: No guests (Eberhard Wolff moderator)  

### Notes
- Episode 190: Fixed incorrect automatic detection of "Spring" as guest (it's a framework)
- Episode gaps 177-185 don't exist in repository, filled with Episode 176

### Next Batches
Will continue with episodes 177-185 and 175 down to 166, maintaining 10 episodes per PR.

Part of Issue #60 implementation.