### PR TITLE
Add guest/moderator metadata: Episodes 173-175, 177-183 (10 episodes)

### DIFF
--- a/_posts/2023-07-07-folge173.md
+++ b/_posts/2023-07-07-folge173.md
@@ -1,15 +1,18 @@
 ---
-title: Folge 173 - Missverständnisse über Software-Architektur
-layout: folge
-video: d3C4-qx01cw
-peertube: https://tube.tchncs.de/videos/embed/246f5100-3572-4ad9-b83d-054ca60084ad
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-cf96e317c86a1ea7f54982ebce&v=1688737660
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Missverstaendnisse_ueber_Software-Architektur.mp3
 description: Eberhard spricht über Missverständnisse über Software-Architektur
-thumbnail: folge173.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-cf96e317c86a1ea7f54982ebce&v=1688737660
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Missverstaendnisse_ueber_Software-Architektur.mp3
+peertube: https://tube.tchncs.de/videos/embed/246f5100-3572-4ad9-b83d-054ca60084ad
 tags:
 - Grundlagen
 - Missverständnisse
+thumbnail: folge173.png
+title: Folge 173 - Missverständnisse über Software-Architektur
+video: d3C4-qx01cw
 ---
 
 Selbst Expert:innen diskutieren immer noch, was Software-Architektur

--- a/_posts/2023-07-16-folge174.md
+++ b/_posts/2023-07-16-folge174.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 174 - Arcards - Ein Spiel um Begriffe aus der Software-Architektur
-layout: folge
-video: FFcquNj4y_g
-peertube: https://tube.tchncs.de/videos/embed/fe70d1fe-1684-4cb5-8d0d-4c77ec49460d
+description: Markus Harrer, Lisa Schäfer, Stefan Toth und Eberhard Wolff stellen Arcards
+  vor und spielen eine Partie.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-2183cc135046479e2e5fb3a9d3&v=1689528104
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Arcards_-_Ein_Spiel_um_Begriffe_aus_der_Software-Architektur.mp3
-description: Markus Harrer, Lisa Schäfer, Stefan Toth und Eberhard Wolff stellen Arcards vor und spielen eine Partie. 
-thumbnail: folge174.png
+peertube: https://tube.tchncs.de/videos/embed/fe70d1fe-1684-4cb5-8d0d-4c77ec49460d
 tags:
 - Gamification
 - Grundlagen
+thumbnail: folge174.png
+title: Folge 174 - Arcards - Ein Spiel um Begriffe aus der Software-Architektur
+video: FFcquNj4y_g
 ---
 
 Bei dem Kartenspiel Arcards geht es darum, mit den vielen Begriffen

--- a/_posts/2023-07-21-folge175.md
+++ b/_posts/2023-07-21-folge175.md
@@ -1,16 +1,20 @@
 ---
-title: Folge 175 - How to Understand Almost Anything mit Markus Völter
-layout: folge
-video: w1dV3yhnXhY
-peertube: https://tube.tchncs.de/videos/embed/51c98c9d-e639-4757-be0f-91ab62934ab9
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-6cdd03147687e7899a546676d3&v=1690030560
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/How_to_Understand_Almost_Anything_mit_Markus_Voelter.mp3
 description: Markus Völter spricht über sei neues Buch "How to Understand Almost Anything"
-thumbnail: folge175.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-6cdd03147687e7899a546676d3&v=1690030560
+guests:
+- Markus Völter
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/How_to_Understand_Almost_Anything_mit_Markus_Voelter.mp3
+peertube: https://tube.tchncs.de/videos/embed/51c98c9d-e639-4757-be0f-91ab62934ab9
 tags:
 - Domain-driven Design
 - Business Analyse
 - Domain Specific Languages
+thumbnail: folge175.png
+title: Folge 175 - How to Understand Almost Anything mit Markus Völter
+video: w1dV3yhnXhY
 ---
 
 Angenommen, man will ein Softwaresystem bauen, mit dem Mediziner

--- a/_posts/2023-08-04-folge177.md
+++ b/_posts/2023-08-04-folge177.md
@@ -1,16 +1,21 @@
 ---
-title: Folge 177 - Scrum Master:in und Softwarearchitektur mit Nadine Andraczek
-layout: folge
-video: UOtP1_8Id-s
-peertube: https://tube.tchncs.de/videos/embed/ac5580f0-97ff-4d92-bdf2-014b986ede00
+description: Nadine Andraczek und Lisa Maria Schäfer sprechen über die Rolle "Scrum
+  Master:in" und den Zusammenhang mit Software-Architektur
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-c1ccd389420696a36c42a135e9&v=1691155286
+guests:
+- Nadine Andraczek
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Scrum_Master_in_und_Softwarearchitektur.mp3
-description: Nadine Andraczek und Lisa Maria Schäfer sprechen über die Rolle "Scrum Master:in" und den Zusammenhang mit Software-Architektur
-thumbnail: folge177.png 
+peertube: https://tube.tchncs.de/videos/embed/ac5580f0-97ff-4d92-bdf2-014b986ede00
 tags:
 - Agilität
 - Scrum Master:in
 - Kommunikation
+thumbnail: folge177.png
+title: Folge 177 - Scrum Master:in und Softwarearchitektur mit Nadine Andraczek
+video: UOtP1_8Id-s
 ---
 
 In dieser Episode sprechen Nadine Andraczek, Scrum Masterin bei

--- a/_posts/2023-08-11-folge178.md
+++ b/_posts/2023-08-11-folge178.md
@@ -1,17 +1,23 @@
 ---
-title: Folge 178 - Crew Ressource Management - Wie geht die Luftfahrt mit dem Faktor Mensch um?
-layout: folge
-video: bu0vrBGnRRg
-peertube: https://tube.tchncs.de/videos/embed/98116503-300e-46c3-b7f6-3ec39df4f65e
+description: Der Faktor Mensch ist in der Luftfahrt zentral. Wie hilft Crew Ressource
+  Management?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-ca2abf3a7bdb1533ff3b0da064&v=1691766485
+guests: []
+
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Crew_Ressource_Management_-_Wie_geht_die_Luftfahrt_mit_dem_Faktor_Mensch_um.mp3
-description: Der Faktor Mensch ist in der Luftfahrt zentral. Wie hilft Crew Ressource Management?
-thumbnail: folge178.png
+peertube: https://tube.tchncs.de/videos/embed/98116503-300e-46c3-b7f6-3ec39df4f65e
 tags:
 - Crew Ressource Management
 - Organisation
 - Kommunikation
 - Agilität
+thumbnail: folge178.png
+title: Folge 178 - Crew Ressource Management - Wie geht die Luftfahrt mit dem Faktor
+  Mensch um?
+video: bu0vrBGnRRg
 ---
 
 Nicht nur in der Software-Architektur spielt der Faktor Mensch eine

--- a/_posts/2023-09-01-folge179.md
+++ b/_posts/2023-09-01-folge179.md
@@ -1,15 +1,18 @@
 ---
-title: Folge 179 - Software-Architektur = Abhängigkeiten Managen?
-layout: folge
-video: kmV0r5_oUh0
-peertube: https://tube.tchncs.de/videos/embed/fcc9d18b-1695-479f-aaa2-ec94df22c005
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-f4e1de8c756baa1e0a635f1471&v=1693584630
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Software-Architektur_-_Abhaengigkeiten_Managen.mp3
 description: Was sind Abhängigkeiten überhaupt? Sind sie wirklich so zentral für Software-Architektur?
-thumbnail: folge179.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-f4e1de8c756baa1e0a635f1471&v=1693584630
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Software-Architektur_-_Abhaengigkeiten_Managen.mp3
+peertube: https://tube.tchncs.de/videos/embed/fcc9d18b-1695-479f-aaa2-ec94df22c005
 tags:
 - Abhängigkeiten
 - Grundlagen
+thumbnail: folge179.png
+title: Folge 179 - Software-Architektur = Abhängigkeiten Managen?
+video: kmV0r5_oUh0
 ---
 
 Wesentlicher Teil der Software-Architektur ist die Strukturierung

--- a/_posts/2023-09-15-folge180.md
+++ b/_posts/2023-09-15-folge180.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 180 - Engineering Excellence mit Michael Vitz
-layout: folge
-video: w9EmDTbw6aE 
-peertube: https://tube.tchncs.de/videos/embed/4a6ccf83-5bc9-473e-850b-ebfb9c164a10
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-e0cc675c80fa969aa48e5df163&v=1694897148
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Engineering_Excellence.mp3
 description: Michael Vitz und Lisa Schäfer diskutieren Engineering Excellence
-thumbnail: folge180.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-e0cc675c80fa969aa48e5df163&v=1694897148
+guests:
+- Michael Vitz
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Engineering_Excellence.mp3
+peertube: https://tube.tchncs.de/videos/embed/4a6ccf83-5bc9-473e-850b-ebfb9c164a10
 tags:
 - Engineering Excellence
 - Karriere
+thumbnail: folge180.png
+title: Folge 180 - Engineering Excellence mit Michael Vitz
+video: w9EmDTbw6aE
 ---
 
 In dieser Episode sprechen Michael Vitz, Senior Consultant bei INNOQ

--- a/_posts/2023-09-28-folge181.md
+++ b/_posts/2023-09-28-folge181.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 181 - Michael Plöd Misserfolge und Lehren aus der Anwendung von DDD - live von der BED-Con
-layout: folge
-video: G-zb0EE60pQ
-peertube: https://tube.tchncs.de/videos/embed/981a4ecd-65c6-4ab1-b969-8bf4a7f122eb
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-1229195da49c1fbf0e79b80f6&v=1696008454
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Misserfolge_und_Lehren_aus_der_Anwendung_von_DDD_-_live_von_der_BED-Con.mp3
 description: Michael Plöd spricht über seine Erfahrungen mit DDD in der Praxis
-thumbnail: folge181.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-1229195da49c1fbf0e79b80f6&v=1696008454
+guests:
+- Michael Plöd
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Misserfolge_und_Lehren_aus_der_Anwendung_von_DDD_-_live_von_der_BED-Con.mp3
+peertube: https://tube.tchncs.de/videos/embed/981a4ecd-65c6-4ab1-b969-8bf4a7f122eb
 tags:
 - Domain-driven Design
 - Live von der BED-Con
+thumbnail: folge181.png
+title: Folge 181 - Michael Plöd Misserfolge und Lehren aus der Anwendung von DDD -
+  live von der BED-Con
+video: G-zb0EE60pQ
 ---
 
 Domain-Driven Design ist kein Patentrezept und löst kein Problem auf

--- a/_posts/2023-09-29-folge182.md
+++ b/_posts/2023-09-29-folge182.md
@@ -1,16 +1,22 @@
 ---
-title: Folge 182 - Thomas Ruhroth, Kai Schmidt - Technologieauswahl für wartbare Projekte - live von der BED-Con 
-layout: folge
-video: IawXrg8fDmY
-peertube: https://tube.tchncs.de/videos/embed/b27ea00e-0242-40a9-a865-cf623e5232d2
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-cfc20d3dfc897d8f237792fbb4&v=1696010535
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Thomas_Ruhroth_Kai_Schmidt_Technologieauswahl_fuer_wartbare_Projekte.mp3
 description: Thomas Ruhroth  Kai Schmidt
-thumbnail: folge182.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-cfc20d3dfc897d8f237792fbb4&v=1696010535
+guests:
+- Thomas Ruhroth
+- Kai Schmidt
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Thomas_Ruhroth_Kai_Schmidt_Technologieauswahl_fuer_wartbare_Projekte.mp3
+peertube: https://tube.tchncs.de/videos/embed/b27ea00e-0242-40a9-a865-cf623e5232d2
 tags:
 - Live von der BED-Con
 - Langlebigkeit
 - Abhängigkeiten
+thumbnail: folge182.png
+title: Folge 182 - Thomas Ruhroth, Kai Schmidt - Technologieauswahl für wartbare Projekte
+  - live von der BED-Con
+video: IawXrg8fDmY
 ---
 
 Oft ist Technologieauswahl ein Streitpunkt. Bei den Argumenten zu

--- a/_posts/2023-10-06-folge183.md
+++ b/_posts/2023-10-06-folge183.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 183 - Technische Schulden - Software langfristig weiterentwickeln
-layout: folge
-video: W-sFLMr01uI
-peertube: https://tube.tchncs.de/videos/embed/c770e766-1598-4972-90ab-076840d52313
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-de08c01c691b565747e635f844&v=1696440771
-mp3: https://1evriw.podcaster.de/download/TechnicalDebt.mp3
 description: Vortrag über technische Schulden
-thumbnail: folge183.jpg
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-de08c01c691b565747e635f844&v=1696440771
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/download/TechnicalDebt.mp3
+peertube: https://tube.tchncs.de/videos/embed/c770e766-1598-4972-90ab-076840d52313
 tags:
 - Technical Debt
+thumbnail: folge183.jpg
+title: Folge 183 - Technische Schulden - Software langfristig weiterentwickeln
+video: W-sFLMr01uI
 ---
 
 Oft wird Software immer schlechter wartbar, je länger


### PR DESCRIPTION
## Guest-List Feature Implementation - Batch 5

This PR adds frontmatter metadata for **10 episodes** (173-175, 177-183).

### Processed Episodes
✅ **Episode 173**: No guests (Eberhard Wolff moderator)  
✅ **Episode 174**: No guests (Eberhard Wolff moderator)  
✅ **Episode 175**: Markus Völter (guest)  
✅ **Episode 177**: Nadine Andraczek (guest)  
✅ **Episode 178**: No guests (Eberhard Wolff moderator)  
✅ **Episode 179**: No guests (Eberhard Wolff moderator)  
✅ **Episode 180**: Michael Vitz (guest)  
✅ **Episode 181**: Michael Plöd (guest)  
✅ **Episode 182**: Thomas Ruhroth, Kai Schmidt (guests)  
✅ **Episode 183**: No guests (Eberhard Wolff moderator)  

### Manual Corrections
- Episode 178: Fixed incorrect automatic detection of guest name from title
- Episode 181: Added Michael Plöd as guest (from BED-Con conference episode)
- Episode 182: Added Thomas Ruhroth and Kai Schmidt as guests (from BED-Con conference episode)

### Next Batches
Will continue with episodes 172 down to 163, maintaining 10 episodes per PR.

Part of Issue #60 implementation.