### PR TITLE
Add guest/moderator metadata: Episodes 163-172 (10 episodes)

### DIFF
--- a/_posts/2023-04-28-folge163.md
+++ b/_posts/2023-04-28-folge163.md
@@ -1,16 +1,20 @@
 ---
-title: Folge 163 - Kommunikation im Entwicklungsprozess mit Rebecca Temme
-layout: folge
-video: Te9CJWK9Hmc
 description: Rebecca Temme spricht mit Lisa Schäfer über Kommunikation im Entwicklungsprozesse
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-aa46a2e88505726a82d894e7ea&v=1682757441
+guests:
+- Rebecca Temme
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Kommunikation_im_Entwicklungsprozess_mit_Rebecca_Temme.mp3
 peertube: https://tube.tchncs.de/videos/embed/2abc3e5d-6781-4960-996f-1661ef6dfc4a
-thumbnail: folge163.png
 tags:
 - Organisation
 - Soft Skills
 - Kommunikation
+thumbnail: folge163.png
+title: Folge 163 - Kommunikation im Entwicklungsprozess mit Rebecca Temme
+video: Te9CJWK9Hmc
 ---
 
 In dieser Episode sprechen Rebecca Temme und Lisa Schäfer darüber, was

--- a/_posts/2023-05-17-folge164.md
+++ b/_posts/2023-05-17-folge164.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 164 - Vom Wissensgefälle zur Selbstorganisation mit Melanie Schäfer
-layout: folge
-video: utPlRMnvINI
-peertube: https://tube.tchncs.de/videos/embed/186d3bba-02b8-4ce0-b931-bafae16294cd
+description: Nicht nur Architekt:innen müssen mit ihrem Wissen anderen helfen - dazu
+  gibt Melanie Schäfer wichtige Hinweise.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-b2c546e51f6dd6c8f8fc084f0c&v=1684336189
+guests:
+- Melanie Schäfer
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Vom_Wissensgefaelle_zur_Selbstorganisation_mit_Melanie_Schaefer.mp3
-description: Nicht nur Architekt:innen müssen mit ihrem Wissen anderen helfen - dazu gibt Melanie Schäfer wichtige Hinweise.
-thumbnail: folge164.png
+peertube: https://tube.tchncs.de/videos/embed/186d3bba-02b8-4ce0-b931-bafae16294cd
 tags:
 - Organisation
 - Agilität
+thumbnail: folge164.png
+title: Folge 164 - Vom Wissensgefälle zur Selbstorganisation mit Melanie Schäfer
+video: utPlRMnvINI
 ---
 
 In Beratungen, Architektur und Trainings kommt es oft zu einem

--- a/_posts/2023-05-19-folge165.md
+++ b/_posts/2023-05-19-folge165.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 165 - Amazon - Von Microservices zurück zu Monolithen?
-layout: folge
-video: 67PEUkeg_jo
-peertube: https://tube.tchncs.de/videos/embed/f3883d24-fc25-44c2-9e8b-7fbd0a06ede7
+description: Amazon kehrt Microservices den Rücken? Nein, Architektur muss iterativ
+  angepasst werden.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-81f2cbea60b32ee27cb1c8af1&v=1684502196
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Amazon_Von_Microservices_zurueck_zu_Monolithen.mp3
-description: Amazon kehrt Microservices den Rücken? Nein, Architektur muss iterativ angepasst werden.
-thumbnail: folge165.png
+peertube: https://tube.tchncs.de/videos/embed/f3883d24-fc25-44c2-9e8b-7fbd0a06ede7
 tags:
 - Microservices
+thumbnail: folge165.png
+title: Folge 165 - Amazon - Von Microservices zurück zu Monolithen?
+video: 67PEUkeg_jo
 ---
 
 Die Software-Architektur-Szene explodiert: Angeblich rudert Amazon

--- a/_posts/2023-05-26-folge166.md
+++ b/_posts/2023-05-26-folge166.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 166 - Zero Trust mit Christoph Iserlohn 
-layout: folge
-video: sNTHcYLAQkg
-peertube: https://tube.tchncs.de/videos/embed/39fc5fc3-b6a0-4aba-afef-837dee5a9538
+description: Christoph und Lisa diskutieren das Sicherheitskonzept Zero Trust
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-778747c1f8611c82813bbde1eb&v=1685106209
+guests:
+- Christoph Iserlohn
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Zero_Trust_mit_Christoph_Iserlohn.mp3
-description: Christoph und Lisa diskutieren das Sicherheitskonzept Zero Trust 
-thumbnail: folge166.png
+peertube: https://tube.tchncs.de/videos/embed/39fc5fc3-b6a0-4aba-afef-837dee5a9538
 tags:
 - Sicherheit
+thumbnail: folge166.png
+title: Folge 166 - Zero Trust mit Christoph Iserlohn
+video: sNTHcYLAQkg
 ---
 
 In dieser Episode sprechen Christoph Iserlohn und Lisa Schäfer über das

--- a/_posts/2023-06-02-folge167.md
+++ b/_posts/2023-06-02-folge167.md
@@ -1,15 +1,21 @@
 ---
-title: Folge 167 - Psychological Safety - was sagt der Psychologe dazu? mit Joseph Pelrine - OOP Special 
-layout: folge
-video: gI44roShx84
-peertube: https://tube.tchncs.de/videos/embed/62f9f7e8-ae6a-4dd4-978e-ca2ec00ca9bc
+description: Joseph Pelrine diskutiert psychological Safety mit der Expertise eines
+  Psychologen
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-ed5895b0a411f3c7f454c742b8&v=1685711884
+guests:
+- Joseph Pelrine
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Psychological_Safety_-_was_sagt_der_Psychologe_dazu_mit_Joseph_Pelrine.mp3
-description: Joseph Pelrine diskutiert psychological Safety mit der Expertise eines Psychologen
-thumbnail: folge167.png
+peertube: https://tube.tchncs.de/videos/embed/62f9f7e8-ae6a-4dd4-978e-ca2ec00ca9bc
 tags:
 - Psychological Safety
 - Organisation
+thumbnail: folge167.png
+title: Folge 167 - Psychological Safety - was sagt der Psychologe dazu? mit Joseph
+  Pelrine - OOP Special
+video: gI44roShx84
 ---
 
 Psychological Safety ist gerade im Bereich Software-Entwicklung ein

--- a/_posts/2023-06-07-folge168.md
+++ b/_posts/2023-06-07-folge168.md
@@ -1,15 +1,19 @@
 ---
-title: Episode 168 - Hands-on Behavioral Code Analysis with Adam Tornhill
-layout: folge
-video: kbQavUHrGBc
-peertube: https://tube.tchncs.de/videos/embed/4876bc2b-ce0b-474f-972c-b1b5a9dc9fa3
+description: Adam Tornhill shows how to behavioral code analysis with the tool CodeScene.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-86b4d428c32ef850978adff674&v=1686143918
+guests:
+- Adam Tornhill
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Hands-on_Behavioral_Code_Analysis_with_Adam_Tornhill.mp3
-description: Adam Tornhill shows how to behavioral code analysis with the tool CodeScene. 
-thumbnail: episode168.png
+peertube: https://tube.tchncs.de/videos/embed/4876bc2b-ce0b-474f-972c-b1b5a9dc9fa3
 tags:
 - English
 - Architecture Management
+thumbnail: episode168.png
+title: Episode 168 - Hands-on Behavioral Code Analysis with Adam Tornhill
+video: kbQavUHrGBc
 ---
 
 When discussing software architecture, it is important to take into

--- a/_posts/2023-06-16-folge169.md
+++ b/_posts/2023-06-16-folge169.md
@@ -1,18 +1,23 @@
 ---
-title: Episode 169 - Systems Thinking in Large-Scale Modeling with Xin Yao - OOP Special
-layout: folge
-video: gkYRKvPL2OA
-sketchnote-video: Lhh1o_a9uP0 
-sketchnote-video-header: YouTube Video Part II
-peertube: https://tube.tchncs.de/videos/embed/a4e1b73a-57fe-4460-9f0a-39d75cda843f
+description: Xin Yao talks about how Systems thinking helps to work with socio-technical
+  systems.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-81c989df4c8ca304e49b29786e&v=1686920466
+guests:
+- Xin Yao
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Systems_Thinking_in_Large-Scale_Modeling_with_Xin_Yao_-_OOP_Special.mp3
-description: Xin Yao talks about how Systems thinking helps to work with socio-technical systems.
-thumbnail: episode169.png
+peertube: https://tube.tchncs.de/videos/embed/a4e1b73a-57fe-4460-9f0a-39d75cda843f
+sketchnote-video: Lhh1o_a9uP0
+sketchnote-video-header: YouTube Video Part II
 tags:
 - English
 - Systems Thinking
 - Soziotechnische Systeme
+thumbnail: episode169.png
+title: Episode 169 - Systems Thinking in Large-Scale Modeling with Xin Yao - OOP Special
+video: gkYRKvPL2OA
 ---
 
 Software development is at the core a human activity - and the created

--- a/_posts/2023-06-23-folge170.md
+++ b/_posts/2023-06-23-folge170.md
@@ -1,17 +1,24 @@
 ---
-title: Folge 170 - Disziplinübergreifende Zusammenarbeit in cross-funktionalen Teams Andrea Nutsi & Cornelia Seraphin - OOP Special 
-layout: folge
-video: 7c0AMnxo9ZI
-peertube: https://tube.tchncs.de/videos/embed/059b0d7f-3db8-430e-b8bb-92b2e32f2349
+description: Zusammenarbeit z.B. mit Requirements Engineering und User Experience
+  in agilen Projekten
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-dcc5365d085eff1dd7439cef68&v=1687589832
+guests:
+- Andrea Nutsi
+- Cornelia Seraphin
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Disziplinuebergreifende_Zusammenarbeit_in_cross-funktionalen_Teams_-_OOP_Special_mit_Andrea_Nutsi_-_Cornelia_Seraphin.mp3
-description: Zusammenarbeit z.B. mit Requirements Engineering und User Experience in agilen Projekten
-thumbnail: episode170.png
+peertube: https://tube.tchncs.de/videos/embed/059b0d7f-3db8-430e-b8bb-92b2e32f2349
 tags:
 - Cross-funktional
 - Organisation
 - UX
 - Requirements Engineering
+thumbnail: episode170.png
+title: Folge 170 - Disziplinübergreifende Zusammenarbeit in cross-funktionalen Teams
+  Andrea Nutsi & Cornelia Seraphin - OOP Special
+video: 7c0AMnxo9ZI
 ---
 
 Andrea Nutsi, Cornelia Seraphin und Lisa Schäfer sprechen in dieser

--- a/_posts/2023-06-30-folge171.md
+++ b/_posts/2023-06-30-folge171.md
@@ -1,14 +1,19 @@
 ---
-title: Folge 171 - Gamification nicht nur in der Qualitätssicherung mit Dehla Sokenou (OOP Special)
-layout: folge
-video: sdJxLe_nWFc
-peertube: https://tube.tchncs.de/videos/embed/05664ae7-3a26-48ec-8860-0540f419c0db
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-fd566c488845358d30b2fd1241&v=1688128545
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Gamification_nicht_nur_in_der_Qualitaetssicherung_mit_Dehla_Sokenou.mp3
 description: Dehla Sokenou berichtet über Gamification vor allem für Testen
-thumbnail: folge171.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-fd566c488845358d30b2fd1241&v=1688128545
+guests:
+- Dehla Sokenou
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Gamification_nicht_nur_in_der_Qualitaetssicherung_mit_Dehla_Sokenou.mp3
+peertube: https://tube.tchncs.de/videos/embed/05664ae7-3a26-48ec-8860-0540f419c0db
 tags:
 - Gamification
+thumbnail: folge171.png
+title: Folge 171 - Gamification nicht nur in der Qualitätssicherung mit Dehla Sokenou
+  (OOP Special)
+video: sdJxLe_nWFc
 ---
 
 Wenn in das Projekt der Alltag einzieht, unbeliebte Aufgaben

--- a/_posts/2023-07-04-folge172.md
+++ b/_posts/2023-07-04-folge172.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 172 - AUA - Ask Us Anything live von der OOP
-layout: folge
-video: UwkisRi7g4c
-peertube: https://tube.tchncs.de/videos/embed/c81116b3-3e07-4775-96fa-5670972ba911
+description: Lisa Schäfer und Eberhard Wolff beantworten Fragen des Publikums auf
+  der OOP
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-757a357d21ad8a47e41f82852e&v=1688489055
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/AUA_-_Ask_Us_Anything_live_von_der_OOP.mp3
-description: Lisa Schäfer und Eberhard Wolff beantworten Fragen des Publikums auf der OOP
-thumbnail: folge172.png
+peertube: https://tube.tchncs.de/videos/embed/c81116b3-3e07-4775-96fa-5670972ba911
 tags:
 - Q&A
+thumbnail: folge172.png
+title: Folge 172 - AUA - Ask Us Anything live von der OOP
+video: UwkisRi7g4c
 ---
 
 Lisa Schäfer und Eberhard Wolff melden sich live von der OOP Konferenz


### PR DESCRIPTION
## Guest-List Feature Implementation - Batch 6

This PR adds frontmatter metadata for **10 episodes** (163-172).

### Processed Episodes
✅ **Episode 163**: Rebecca Temme (guest)  
✅ **Episode 164**: Melanie Schäfer (guest)  
✅ **Episode 165**: No guests (Eberhard Wolff moderator)  
✅ **Episode 166**: Christoph Iserlohn (guest)  
✅ **Episode 167**: Joseph Pelrine (guest)  
✅ **Episode 168**: Adam Tornhill (guest)  
✅ **Episode 169**: Xin Yao (guest)  
✅ **Episode 170**: Andrea Nutsi, Cornelia Seraphin (guests)  
✅ **Episode 171**: Dehla Sokenou (guest)  
✅ **Episode 172**: No guests (Eberhard Wolff moderator)  

### Manual Corrections
- Episode 167, 169: Cleaned "OOP Special" suffix from guest names
- Episode 170: Added Andrea Nutsi and Cornelia Seraphin as guests (from title analysis)

### Next Batches
Will continue with episodes 162 down to 153, maintaining 10 episodes per PR.

Part of Issue #60 implementation.