### PR TITLE
Add guest/moderator metadata: Episodes 153-162 (10 episodes)

### DIFF
--- a/_posts/2023-02-24-folge153.md
+++ b/_posts/2023-02-24-folge153.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 153 - Domain-driven Design - nur vernünftige Software-Entwicklung?
-layout: folge
-video: o1m80WbiFBU
-peertube: https://tube.tchncs.de/videos/embed/717e88b0-8e86-4c26-ab92-f342bc4ee266
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-96bf8e5e401dc0fe66e2601186&v=1677248818
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Domain-driven_Design_nur_vernuenftige_Software-Entwicklung.mp3
 description: Was macht DDD wirklich aus und was hilft und die Erkenntnis?
-thumbnail: folge153.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-96bf8e5e401dc0fe66e2601186&v=1677248818
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Domain-driven_Design_nur_vernuenftige_Software-Entwicklung.mp3
+peertube: https://tube.tchncs.de/videos/embed/717e88b0-8e86-4c26-ab92-f342bc4ee266
 tags:
 - Domain-driven Design
+thumbnail: folge153.png
+title: Folge 153 - Domain-driven Design - nur vernünftige Software-Entwicklung?
+video: o1m80WbiFBU
 ---
 
 Domain-driven Design (DDD) ist über die Jahre zu einer umfangreichen

--- a/_posts/2023-03-03-folge154.md
+++ b/_posts/2023-03-03-folge154.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 154 - Serverless Architektur mit Sascha Möllering
-layout: folge
-video: PN6Tj_9JOGk
-peertube: https://tube.tchncs.de/videos/embed/6285bef9-82e8-463d-9283-6db0290e892c
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-84d2ffafc1d571187e962182e5&v=1677873609
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Serverless_Architektur_mit_Sascha_Moellering.mp3
 description: Sascha Möllering von AWS spricht über Serverless Architekture
-thumbnail: folge154.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-84d2ffafc1d571187e962182e5&v=1677873609
+guests:
+- Sascha Möllering
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Serverless_Architektur_mit_Sascha_Moellering.mp3
+peertube: https://tube.tchncs.de/videos/embed/6285bef9-82e8-463d-9283-6db0290e892c
 tags:
 - Cloud
 - Serverless
+thumbnail: folge154.png
+title: Folge 154 - Serverless Architektur mit Sascha Möllering
+video: PN6Tj_9JOGk
 ---
 
 Serverless ist die neueste Evolutionsstufe der Infrastrukturen - und

--- a/_posts/2023-03-10-folge155.md
+++ b/_posts/2023-03-10-folge155.md
@@ -1,10 +1,16 @@
 ---
-title: Folge 155 - Sichere Architekturen – Wie die OWASP helfen kann mit Christoph Iserlohn
-layout: folge
-video: tJZ4AEc-yc8
-peertube: https://tube.tchncs.de/videos/embed/f5495600-e81e-4cd9-af02-9b630a797ff9
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-6095b1e59bb34e2ced5cad6e07&v=1678467903
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Sichere_Architekturen_---_Wie_die_OWASP_helfen_kann_mit_Christoph_Iserlohn_und_Lisa_Moritz.mp3
+guests:
+- Christoph Iserlohn
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Sichere_Architekturen_
+peertube: https://tube.tchncs.de/videos/embed/f5495600-e81e-4cd9-af02-9b630a797ff9
+title: Folge 155 - Sichere Architekturen – Wie die OWASP helfen kann mit Christoph
+  Iserlohn
+video: tJZ4AEc-yc8
+---_Wie_die_OWASP_helfen_kann_mit_Christoph_Iserlohn_und_Lisa_Moritz.mp3
 description: OWASP bietet viele nützliche Ressourcen für die Sicherheit von Software. Christoph Iserlohn und Lisa Schäfer bieten einen Überblick. 
 thumbnail: folge155.png
 tags:

--- a/_posts/2023-03-14-folge156.md
+++ b/_posts/2023-03-14-folge156.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 156 - Funktionale Programmierung, DDD und Architektur mit Mike Sperber
-layout: folge
-video: 1ISYi90G-mY
-peertube: https://tube.tchncs.de/videos/embed/ad0dc359-7bf9-47a9-9a71-4cbcfe2f7f95
-description: Mike Sperber spricht über den Einfluss funktionaler Programmierung auf Architektur und Domain-driven Design (DDD)
-thumbnail: folge156.png
+description: Mike Sperber spricht über den Einfluss funktionaler Programmierung auf
+  Architektur und Domain-driven Design (DDD)
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-0346b3c1ffbfe78de753ec081&v=1678874468
+guests:
+- Mike Sperber
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Funktionale_Programmierung-_DDD_und_Architektur_mit_Mike_Sperber.mp3
+peertube: https://tube.tchncs.de/videos/embed/ad0dc359-7bf9-47a9-9a71-4cbcfe2f7f95
 tags:
 - Funktionale Programmierung
 - Domain-driven Design
+thumbnail: folge156.png
+title: Folge 156 - Funktionale Programmierung, DDD und Architektur mit Mike Sperber
+video: 1ISYi90G-mY
 ---
 
 Neben dem objektorientierten und imperativen Paradigma gibt es schon

--- a/_posts/2023-03-17-folge157.md
+++ b/_posts/2023-03-17-folge157.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 157 - Single Source of Truth mit Gerrit Beine
-layout: folge
-video: z1b-m4Pio0E
-peertube: https://tube.tchncs.de/videos/embed/38448ad0-ee50-419c-92ed-1f06e3414b5d
+description: Wir diskutieren mit Gerrit Beine, dass es eine Single Source of Truth
+  mit den "richtigen" Daten bzw. Berechnungen es nicht geben kann und soll.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-2632bf0a2a362ce980e14c461c&v=1679060315
+guests:
+- Gerrit Beine
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Single_Source_of_Truth_mit_Gerrit_Beine.mp3
-description: Wir diskutieren mit Gerrit Beine, dass es eine Single Source of Truth mit den "richtigen" Daten bzw. Berechnungen es nicht geben kann und soll.
-thumbnail: folge157.png
+peertube: https://tube.tchncs.de/videos/embed/38448ad0-ee50-419c-92ed-1f06e3414b5d
 tags:
 - Single Source of Truth
 - Modularisierung
+thumbnail: folge157.png
+title: Folge 157 - Single Source of Truth mit Gerrit Beine
+video: z1b-m4Pio0E
 ---
 
 In Systemen gibt es oft redundante Implementierung von Logik oder

--- a/_posts/2023-03-24-folge158.md
+++ b/_posts/2023-03-24-folge158.md
@@ -1,15 +1,21 @@
 ---
-title: Folge 158 - Eindrücke von der JavaLand mit Nora Schöner und Lisa Schäfer
-layout: folge
-video: 6faHlYeVDz8
-peertube: https://tube.tchncs.de/videos/embed/8b7e43a0-133c-4c3d-a295-83024e845b7a
+description: Nora Schöner und Lisa Schäfer berichten von ihren Eindrücken von der
+  JavaLand-Konferenz
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-5add14fcc24ac1491b647f19c2&v=1679667849
+guests:
+- Nora Schöner
+- Lisa Schäfer
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Eindruecke_von_der_JavaLand_mit_Nora_Schoener_und_Lisa_Moritz.mp3
-description: Nora Schöner und Lisa Schäfer berichten von ihren Eindrücken von der JavaLand-Konferenz
-thumbnail: folge158.png
+peertube: https://tube.tchncs.de/videos/embed/8b7e43a0-133c-4c3d-a295-83024e845b7a
 tags:
 - JavaLand
 - Konferenz
+thumbnail: folge158.png
+title: Folge 158 - Eindrücke von der JavaLand mit Nora Schöner und Lisa Schäfer
+video: 6faHlYeVDz8
 ---
 
 Nora Schöner und Lisa Moriz sprechen über ihre Eindrücke und

--- a/_posts/2023-03-31-folge159.md
+++ b/_posts/2023-03-31-folge159.md
@@ -1,15 +1,18 @@
 ---
-title: Folge 159 - Big Ball of Mud 
-layout: folge
-video: Gqs8zLXei7Q
-peertube: https://tube.tchncs.de/videos/embed/ba1e4ff5-2fe9-4246-9f6a-b4ce25be2c9a
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-356f8f0c8161c162c999f31a72&v=1680273763
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Big_Ball_of_Mud.mp3
 description: Big Ball of Mud Architektur des Grauens? Nein, sie hat auch Vorteile
-thumbnail: folge159.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-356f8f0c8161c162c999f31a72&v=1680273763
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Big_Ball_of_Mud.mp3
+peertube: https://tube.tchncs.de/videos/embed/ba1e4ff5-2fe9-4246-9f6a-b4ce25be2c9a
 tags:
 - Big Ball of Mud
 - Legacy
+thumbnail: folge159.png
+title: Folge 159 - Big Ball of Mud
+video: Gqs8zLXei7Q
 ---
 
 "Big Ball of Mud" bezeichnet Software, die keine erkennbare Struktur

--- a/_posts/2023-04-14-folge160.md
+++ b/_posts/2023-04-14-folge160.md
@@ -1,15 +1,18 @@
 ---
-title: Folge 160 - Cloud Native - Was und warum?
-layout: folge
-video: fnCD_Y6uxXo
-peertube: https://tube.tchncs.de/videos/embed/98df70ce-f740-4574-80ce-4fe61860cb77
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-76a928f9e12095e0f7827cc9ae&v=1681475842
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Cloud_Native_Was_und_warum.mp3
 description: Was ist Cloud Native und wann sollte man es nutzen?
-thumbnail: episode160.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-76a928f9e12095e0f7827cc9ae&v=1681475842
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Cloud_Native_Was_und_warum.mp3
+peertube: https://tube.tchncs.de/videos/embed/98df70ce-f740-4574-80ce-4fe61860cb77
 tags:
 - Cloud Native
 - Cloud
+thumbnail: episode160.png
+title: Folge 160 - Cloud Native - Was und warum?
+video: fnCD_Y6uxXo
 ---
 
 Cloud Native ist einer der großen Trends in der

--- a/_posts/2023-04-21-folge161.md
+++ b/_posts/2023-04-21-folge161.md
@@ -1,16 +1,21 @@
 ---
-title: Folge 161 - Business Analyst:in und Software-Architektur mit Michaela Kühn
-layout: folge
-video: ARdLsB_1cik
-peertube: https://tube.tchncs.de/videos/embed/3b9e879a-eef9-44d5-9bb5-27196178de20
+description: Michaela Kühn und Lisa Schäfer diskutieren die Rolle Business-Analyst:in
+  und den Zusammenhang zur Architektur
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-8aeaa8e65b323f290df1f6f8bc&v=1682080890
+guests:
+- Michaela Kühn
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Business_Analystin_und_Software-Architektur_mit_Michaela_Kuehn.mp3
-description: Michaela Kühn und Lisa Schäfer diskutieren die Rolle Business-Analyst:in und den Zusammenhang zur Architektur
-thumbnail: folge161.png
+peertube: https://tube.tchncs.de/videos/embed/3b9e879a-eef9-44d5-9bb5-27196178de20
 tags:
 - Business Analyse
 - Grundlagen
 - Karriere
+thumbnail: folge161.png
+title: Folge 161 - Business Analyst:in und Software-Architektur mit Michaela Kühn
+video: ARdLsB_1cik
 ---
 
 In dieser Episode sprechen Michaela Kühn und Lisa Schäfer über den

--- a/_posts/2023-04-27-folge162.md
+++ b/_posts/2023-04-27-folge162.md
@@ -1,14 +1,20 @@
 ---
-title: Folge 162 -  Die IT-Welt vor 10 Jahren mit Stefan Tilkov und Eberhard Wolff - live von der RheinJUG
-layout: folge
-video: Q9RrBwRt8sE
-description: Stefan und Eberhard diskutieren die IT-Welt vor 10 Jahren - und was sie für heute bedeutet.
-thumbnail: folge162.png
+description: Stefan und Eberhard diskutieren die IT-Welt vor 10 Jahren - und was sie
+  für heute bedeutet.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-83867ba016a0fa235bb3cadfcd&v=1682763853
+guests:
+- Stefan Tilkov
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Die_IT-Welt_vor_10_Jahren_mit_Stefan_Tilkov_und_Eberhard_Wolff_-_live_von_der_RheinJUG.mp3
 peertube: https://tube.tchncs.de/videos/embed/c04a08bb-969d-4c13-bd24-7aa756520ade
 tags:
 - Historisch
+thumbnail: folge162.png
+title: Folge 162 -  Die IT-Welt vor 10 Jahren mit Stefan Tilkov und Eberhard Wolff
+  - live von der RheinJUG
+video: Q9RrBwRt8sE
 ---
 
 Die Innovationsgeschwindigkeit in der IT ist unfassbar hoch - so meint


### PR DESCRIPTION
## Guest-List Feature Implementation - Batch 7

This PR adds frontmatter metadata for **10 episodes** (153-162).

### Processed Episodes
✅ **Episode 153**: No guests (Eberhard Wolff moderator)  
✅ **Episode 154**: Sascha Möllering (guest)  
✅ **Episode 155**: Christoph Iserlohn (guest)  
✅ **Episode 156**: Mike Sperber (guest)  
✅ **Episode 157**: Gerrit Beine (guest)  
✅ **Episode 158**: Nora Schöner, Lisa Schäfer (guests)  
✅ **Episode 159**: No guests (Eberhard Wolff moderator)  
✅ **Episode 160**: No guests (Eberhard Wolff moderator)  
✅ **Episode 161**: Michaela Kühn (guest)  
✅ **Episode 162**: Stefan Tilkov (guest)  

### Manual Corrections
- Episode 158: Separated "Nora Schöner und Lisa Schäfer" into two individual guests
- Episode 162: Stefan Tilkov as guest (live RheinJUG episode with both moderators)

Part of Issue #60 implementation.