### PR TITLE
Add guest/moderator metadata: Episodes 142-150, 152 (10 episodes)

### DIFF
--- a/_posts/2022-11-11-folge142.md
+++ b/_posts/2022-11-11-folge142.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 142 - Best Practices - Keine gute Idee
-layout: folge
-video: in6qdwIzEgw
-peertube: https://tube.tchncs.de/videos/embed/87e03fee-b4cc-4a64-ac0e-37bfe6e581f6
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-9b1695b56a7132092f25f6358c&v=1668171886
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Best_Practices_Keine_gute_Idee.mp3
 description: Best Practices sind meistens keine gute Idee - warum?
-thumbnail: folge142.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-9b1695b56a7132092f25f6358c&v=1668171886
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Best_Practices_Keine_gute_Idee.mp3
+peertube: https://tube.tchncs.de/videos/embed/87e03fee-b4cc-4a64-ac0e-37bfe6e581f6
 tags:
 - Best Practice
+thumbnail: folge142.png
+title: Folge 142 - Best Practices - Keine gute Idee
+video: in6qdwIzEgw
 ---
 
 Alle suchen nach Ansätzen, um noch besser Software zu

--- a/_posts/2022-11-18-folge143.md
+++ b/_posts/2022-11-18-folge143.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 143 - Architektur-Migration (nicht nur) zu Microservices
-layout: folge
-video: zFzNe2MTg6Y
-peertube: https://tube.tchncs.de/videos/embed/e5274717-473c-4656-9f72-fafa2fe52c71
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-01adfe583b22b5f4130a9dd743&v=1668776286
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Architektur-Migration_(nicht_nur)_zu_Microservices.mp3
 description: Wie migriert man zu einer neuen Architektur?
-thumbnail: folge143.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-01adfe583b22b5f4130a9dd743&v=1668776286
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Architektur-Migration_(nicht_nur)_zu_Microservices.mp3
+peertube: https://tube.tchncs.de/videos/embed/e5274717-473c-4656-9f72-fafa2fe52c71
 tags:
 - Migration
+thumbnail: folge143.png
+title: Folge 143 - Architektur-Migration (nicht nur) zu Microservices
+video: zFzNe2MTg6Y
 ---
 
 Die Architekturen vieler Systeme sind suboptimal. Was liegt näher, als

--- a/_posts/2022-11-25-folge144.md
+++ b/_posts/2022-11-25-folge144.md
@@ -1,16 +1,19 @@
 ---
-title: Folge 144 -  Continuous Delivery - Eine Kultur?
-layout: folge
-video: EzhWlZ2jyzk
-peertube: https://tube.tchncs.de/videos/embed/9d1f07f0-4bcf-4aa3-bc8f-b48f0e6440aa
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-2f967f9288976fca0408a79c8b&v=1669392635
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Continuous_Delivery_-_Eine_Kultur.mp3
 description: Ist Continuous Delivery im Kern eine Kultur-Frage?
-thumbnail: folge144.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-2f967f9288976fca0408a79c8b&v=1669392635
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Continuous_Delivery_-_Eine_Kultur.mp3
+peertube: https://tube.tchncs.de/videos/embed/9d1f07f0-4bcf-4aa3-bc8f-b48f0e6440aa
 tags:
 - Continuous Delivery
 - DevOps
 - DORA
+thumbnail: folge144.png
+title: Folge 144 -  Continuous Delivery - Eine Kultur?
+video: EzhWlZ2jyzk
 ---
 
 Continuous Delivery ist scheinbar ganz einfach: Software öfter zu

--- a/_posts/2022-12-02-folge145.md
+++ b/_posts/2022-12-02-folge145.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 145 - Jahresrückblick 2022 
-layout: folge
-video: 8N2AOH2BND8
-peertube: https://tube.tchncs.de/videos/embed/a231d30f-e95d-4f82-8848-1f825b4077e8
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-d18fe3f793e33b62cb85425538&v=1669986966
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Jahresrueckblick_2022.mp3
 description: Lisa und Eberhard blicken auf den Episoden des Jahres 2022 zurück
-thumbnail: folge145.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-d18fe3f793e33b62cb85425538&v=1669986966
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Jahresrueckblick_2022.mp3
+peertube: https://tube.tchncs.de/videos/embed/a231d30f-e95d-4f82-8848-1f825b4077e8
 tags:
 - Jahresrückblick
+thumbnail: folge145.png
+title: Folge 145 - Jahresrückblick 2022
+video: 8N2AOH2BND8
 ---
 
 Langsam neigt sich das Jahr dem Ende zu. In dieser Episode diskutieren

--- a/_posts/2022-12-16-folge146.md
+++ b/_posts/2022-12-16-folge146.md
@@ -1,15 +1,21 @@
 ---
-title: Folge 146 - Mehr als Pfeile und Kästen - Architekturdiagramme mit Ralf D. Müller und Lisa Schäfer 
-layout: folge
-video: U5e7F3LnHvY
-peertube: https://tube.tchncs.de/videos/embed/2e37f79e-181a-4259-bfa5-5462aba087cd
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-ecff7d1d9613d102a49d4f3d62&v=1671197570
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Mehr_als_Pfeile_und_Kaesten_Architekturdiagramme_mit_Ralf_D_Mueller_und_Lisa_Moritz.mp3
 description: Lisa und Ralf diskutieren gute Architektur-Diagramme
-thumbnail: folge146.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-ecff7d1d9613d102a49d4f3d62&v=1671197570
+guests:
+- Ralf D. Müller
+- Lisa Schäfer
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Mehr_als_Pfeile_und_Kaesten_Architekturdiagramme_mit_Ralf_D_Mueller_und_Lisa_Moritz.mp3
+peertube: https://tube.tchncs.de/videos/embed/2e37f79e-181a-4259-bfa5-5462aba087cd
 tags:
 - Dokumentation
 - Diagramme
+thumbnail: folge146.png
+title: Folge 146 - Mehr als Pfeile und Kästen - Architekturdiagramme mit Ralf D. Müller
+  und Lisa Schäfer
+video: U5e7F3LnHvY
 ---
 
 Dieses Mal ist Ralf D. Müller bei uns im Stream zu Gast. Lisa und

--- a/_posts/2023-01-13-folge147.md
+++ b/_posts/2023-01-13-folge147.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 147 - Wie reißt man den Elfenbeinturm ein? mit Anja Kammer
-layout: folge
-video: 0mX3trZWux0
-peertube: https://tube.tchncs.de/videos/embed/015b3639-b179-429d-b67b-4d9cc538a96a
+description: Anja und Eberhard diskutieren Möglichkeiten, Architekt*innen aus dem
+  Elfenbeinturm zu bekommen
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-bb74696a9acae974b2307a9da5&v=1673621715
+guests:
+- Anja Kammer
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Wie_reisst_man_den_Elfenbeinturm_ein_mit_Anja_Kammer.mp3
-description: Anja und Eberhard diskutieren Möglichkeiten, Architekt*innen aus dem Elfenbeinturm zu bekommen
-thumbnail: folge147.png
+peertube: https://tube.tchncs.de/videos/embed/015b3639-b179-429d-b67b-4d9cc538a96a
 tags:
 - Organisation
 - Soziotechnische Systeme
+thumbnail: folge147.png
+title: Folge 147 - Wie reißt man den Elfenbeinturm ein? mit Anja Kammer
+video: 0mX3trZWux0
 ---
 
 Oft leben Architekt:innen in einem Elfenbeinturm: Sie treffen

--- a/_posts/2023-01-20-folge148.md
+++ b/_posts/2023-01-20-folge148.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 148 -  Extreme Programming (XP) - eine Retrospektive
-layout: folge
-video: WMql4zcUZKc
-peertube: https://tube.tchncs.de/videos/embed/7710e7f2-88bf-40dd-93c0-40e717e546ee
+description: Extreme Programming (XP) ist mittlerweile >25 Jahre alt - Zeit es kritisch
+  zu bewerten.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-680bbc1ad8767aa339882d5f92&v=1674220755
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Extreme_Programming_(XP)_-_eine_Retrospektive.mp3
-description: Extreme Programming (XP) ist mittlerweile >25 Jahre alt - Zeit es kritisch zu bewerten.
-thumbnail: folge148.png
+peertube: https://tube.tchncs.de/videos/embed/7710e7f2-88bf-40dd-93c0-40e717e546ee
 tags:
 - Extreme Programming
 - Agilität
+thumbnail: folge148.png
+title: Folge 148 -  Extreme Programming (XP) - eine Retrospektive
+video: WMql4zcUZKc
 ---
 
 1995 begann das Chrysler-C3-Projekt. Es wurde als erstes Projekt nach

--- a/_posts/2023-01-27-folge149.md
+++ b/_posts/2023-01-27-folge149.md
@@ -1,15 +1,18 @@
 ---
-title: Folge 149 - Das Strangler Fig Pattern
-layout: folge
-video: QkIdWnwFuqo
-peertube: https://tube.tchncs.de/videos/embed/b4547a44-48b5-4c5a-94e0-2b12c9558dda
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-56e241a13b7a2ea4ef8566abba&v=1674828597
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Das_Strangler_Fig_Pattern.mp3
 description: Strangler Fig Pattern für die Ablösung von Legacy-Systemen
-thumbnail: folge149.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-56e241a13b7a2ea4ef8566abba&v=1674828597
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Das_Strangler_Fig_Pattern.mp3
+peertube: https://tube.tchncs.de/videos/embed/b4547a44-48b5-4c5a-94e0-2b12c9558dda
 tags:
 - Legacy
 - Migration
+thumbnail: folge149.png
+title: Folge 149 - Das Strangler Fig Pattern
+video: QkIdWnwFuqo
 ---
 
 Das Strangler Fig Pattern ist vermutlich der bekannteste Ansatz, um

--- a/_posts/2023-02-03-folge150.md
+++ b/_posts/2023-02-03-folge150.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 150 -  Frontendintegrationsmuster im Web mit Falk Hoppe
-layout: folge
-video: cPGVqvwnWKw
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-08186cb1836789c33c1c79cdaa&v=1675443672
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Frontendintegrationsmuster_im_Web_mit_Falk_Hoppe.mp3
 description: Falk Hoppe und Lisa Schäfer diskutieren Frontendintegrationsmuster
-thumbnail: folge150.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-08186cb1836789c33c1c79cdaa&v=1675443672
+guests:
+- Falk Hoppe
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Frontendintegrationsmuster_im_Web_mit_Falk_Hoppe.mp3
 peertube: https://tube.tchncs.de/videos/embed/a76ac045-d254-4ae4-839f-c088ef233197
 tags:
 - Frontend
+thumbnail: folge150.png
+title: Folge 150 -  Frontendintegrationsmuster im Web mit Falk Hoppe
+video: cPGVqvwnWKw
 ---
 
 Bei dieser Episode ist Falk Hoppe zu Gast bei Softwarearchitektur im

--- a/_posts/2023-02-17-folge152.md
+++ b/_posts/2023-02-17-folge152.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 152 - Das Kippen agiler Software-Projekte
-layout: folge
-video: NjQjSohhX40
-peertube: https://tube.tchncs.de/videos/embed/b09d5231-e534-4e7c-879e-92051e0e1e46
+description: Plötzlich ist das Projekt nicht mehr agil und Leistungsträger verlassen
+  es. Warum und was tun?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-f1fa0c48085a35017915fe0bda&v=1676642666
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Das_Kippen_agiler_Software-Projekte.mp3
-description: Plötzlich ist das Projekt nicht mehr agil und Leistungsträger verlassen es. Warum und was tun?
-thumbnail: folge152.png
+peertube: https://tube.tchncs.de/videos/embed/b09d5231-e534-4e7c-879e-92051e0e1e46
 tags:
 - Agilität
+thumbnail: folge152.png
+title: Folge 152 - Das Kippen agiler Software-Projekte
+video: NjQjSohhX40
 ---
 
 Ein agiles Projekt, sehr produktiv und alle arbeiten mit Begeisterung


### PR DESCRIPTION
## Guest-List Feature Implementation - Batch 8

This PR adds frontmatter metadata for **10 episodes** (142-150, 152).

### Processed Episodes
✅ **Episode 142**: No guests (Eberhard Wolff moderator)  
✅ **Episode 143**: No guests (Eberhard Wolff moderator)  
✅ **Episode 144**: No guests (Eberhard Wolff moderator)  
✅ **Episode 145**: No guests (Eberhard Wolff moderator)  
✅ **Episode 146**: Ralf D. Müller, Lisa Schäfer (guests)  
✅ **Episode 147**: Anja Kammer (guest)  
✅ **Episode 148**: No guests (Eberhard Wolff moderator)  
✅ **Episode 149**: No guests (Eberhard Wolff moderator)  
✅ **Episode 150**: Falk Hoppe (guest)  
✅ **Episode 152**: No guests (Eberhard Wolff moderator)  

### Notes
- Episode 151 doesn't exist in repository
- Episode 146: Separated guests into individual entries

Part of Issue #60 implementation.