### PR TITLE
Add guest metadata: Episodes 46-37 (Batch 17) - addressing #60

### DIFF
--- a/_posts/2021-02-05-folge37.md
+++ b/_posts/2021-02-05-folge37.md
@@ -1,13 +1,17 @@
 ---
-title: Folge 37 - Technische Schulden
-layout: folge
-video: aYE8vfNQulw
+description: Technische Schulden und die schlechte Änderbarkeit von Software ist eine
+  wichtige Herausforderung - wie geht man damit um?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-601eecf4858b3064191360&v=1612641534
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/TechnischeSchulden.mp3
-description: Technische Schulden und die schlechte Änderbarkeit von Software ist eine wichtige Herausforderung - wie geht man damit um?
-thumbnail: folge37.png
 tags:
 - Technical Debt
+thumbnail: folge37.png
+title: Folge 37 - Technische Schulden
+video: aYE8vfNQulw
 ---
 
 Oft wird Software immer schlechter wartbar, je länger

--- a/_posts/2021-02-09-folge38.md
+++ b/_posts/2021-02-09-folge38.md
@@ -1,14 +1,19 @@
 ---
-title: Folge 38 - Michael Mahlberg - Architektur-Entscheidungen finanziell bewerten - Live von der OOP
-layout: folge
-video: y1m6t-FVXiU
+description: Werkzeuge und Hinweise wie man Architektur-Entscheidungen finanziell
+  bewerten kann.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-6029671a56a6f803407981&v=1613328280
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/MichaelMahlberg.mp3
-description: Werkzeuge und Hinweise wie man Architektur-Entscheidungen finanziell bewerten kann.
-thumbnail: OOP.jpg
 tags:
 - Live von der OOP
 - Architektur bewerten
+thumbnail: OOP.jpg
+title: Folge 38 - Michael Mahlberg - Architektur-Entscheidungen finanziell bewerten
+  - Live von der OOP
+video: y1m6t-FVXiU
 ---
 
 Auch Architektur-Entscheidungen müssen wirtschaftlichen Zielen

--- a/_posts/2021-02-09-folge39.md
+++ b/_posts/2021-02-09-folge39.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 39 - Stefan Zörner / Falk Sippach - Architektur-Reviews - Live von der OOP mit Lisa Schäfer
-layout: folge
-video: 8IAdFtTCrt8
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-602969f738bd2201621570&v=1613328280
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/ZoernerSippach.mp3
 description: Praktische Hinweise zu Architektur-Reviews
-thumbnail: OOP.jpg
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-602969f738bd2201621570&v=1613328280
+guests:
+- Lisa Schäfer
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/ZoernerSippach.mp3
 tags:
 - Live von der OOP
 - Architektur bewerten
 - Reviews
+thumbnail: OOP.jpg
+title: Folge 39 - Stefan Zörner / Falk Sippach - Architektur-Reviews - Live von der
+  OOP mit Lisa Schäfer
+video: 8IAdFtTCrt8
 ---
 
 Stefan Zörner und Falk Sippach wollen in ihrem Vortrag auf der OOP

--- a/_posts/2021-02-09-folge40.md
+++ b/_posts/2021-02-09-folge40.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 40 - Susanne Braun - Eventual Consistency - Live von der OOP
-layout: folge
-video: ujwdaEHjba4
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-60296de85f0d0095371987&v=1613328280
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Braun.mp3
 description: Lösungen für Eventual Consistency mit Domain-driven Design
-thumbnail: OOP.jpg
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-60296de85f0d0095371987&v=1613328280
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Braun.mp3
 tags:
 - Live von der OOP
 - Konsistenz
+thumbnail: OOP.jpg
+title: Folge 40 - Susanne Braun - Eventual Consistency - Live von der OOP
+video: ujwdaEHjba4
 ---
 
 Daten-intensive Systeme arbeiten häufig mit Eventual

--- a/_posts/2021-02-10-folge41.md
+++ b/_posts/2021-02-10-folge41.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 41 - Stefan Toth - Enterprise Architektur und Business Agilität - Live von der OOP
-layout: folge
-video: bMAFtHEiB7w
+description: Stefan Toth erläutert, wie Enterprise Architektur und Agilität zusammen
+  passen.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-60327f627f32f040501657&v=1614151242
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Toth.mp3
-description: Stefan Toth erläutert, wie Enterprise Architektur und Agilität zusammen passen.
-thumbnail: OOP.jpg
 tags:
 - Live von der OOP
 - Agilität
 - Enterprise Architektur
+thumbnail: OOP.jpg
+title: Folge 41 - Stefan Toth - Enterprise Architektur und Business Agilität - Live
+  von der OOP
+video: bMAFtHEiB7w
 ---
 
 Enterprise Architektur und Agilität scheinen Widersprüche zu

--- a/_posts/2021-02-10-folge42.md
+++ b/_posts/2021-02-10-folge42.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 42 - Dennis Wagner, Marc Bless - Ernsthafte Spiele - Live von der OOP mit Lisa Schäfer
-layout: folge
-video: gqF123U71u8
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-60328045ee9c8177014051&v=1614151242
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/WagnerBless.mp3
 description: Ernsthafte Spiele können bei der Software-Entwicklung helfen.
-thumbnail: OOP.jpg
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-60328045ee9c8177014051&v=1614151242
+guests:
+- Lisa Schäfer
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/WagnerBless.mp3
 tags:
 - Live von der OOP
 - Gamification
 - Agilität
+thumbnail: OOP.jpg
+title: Folge 42 - Dennis Wagner, Marc Bless - Ernsthafte Spiele - Live von der OOP
+  mit Lisa Schäfer
+video: gqF123U71u8
 ---
 
  “Spiele??? Sind wir denn hier im Kindergarten?!” - Marc und Dennis,

--- a/_posts/2021-02-10-folge43.md
+++ b/_posts/2021-02-10-folge43.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 43 - Lars Röwekamp - Künstliche Intelligenz und Ethik - Live von der OOP 
-layout: folge
-video: bInoWVcssUc
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-603281de977d5507471872&v=1614151242
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Roewekamp.mp3
 description: Gerade bei künstlicher Intelligenz stellt sich die Frage nach der Ethik.
-thumbnail: OOP.jpg
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-603281de977d5507471872&v=1614151242
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Roewekamp.mp3
 tags:
 - Live von der OOP
 - Ethik
 - Künstliche Intelligenz
+thumbnail: OOP.jpg
+title: Folge 43 - Lars Röwekamp - Künstliche Intelligenz und Ethik - Live von der
+  OOP
+video: bInoWVcssUc
 ---
 
 Künstliche Intelligenz kann genderspezifischer Benachteiligung

--- a/_posts/2021-02-11-folge44.md
+++ b/_posts/2021-02-11-folge44.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 44 - Henning Wolf - Agilität - Agility as If You Meant It - Live von der OOP
-layout: folge
-video: 7oPkkSdZCCU
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-603283593b835661745435&v=1614151242
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Wolf.mp3
 description: Was wenn wir Agilität wirklich ernst nehmen?
-thumbnail: OOP.jpg
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-603283593b835661745435&v=1614151242
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Wolf.mp3
 tags:
 - Live von der OOP
 - Agilität
+thumbnail: OOP.jpg
+title: Folge 44 - Henning Wolf - Agilität - Agility as If You Meant It - Live von
+  der OOP
+video: 7oPkkSdZCCU
 ---
 
 Henning Wolf ist agiler Berater und will, dass wir Agilität auch

--- a/_posts/2021-02-11-folge45.md
+++ b/_posts/2021-02-11-folge45.md
@@ -1,14 +1,19 @@
 ---
-title: Folge 45 - Stefan Tilkov - Software-Architektur für verschiedene Zielgruppen - Live von der OOP mit Lisa Schäfer
-layout: folge
-video: NBU4EZapeLQ
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-603283d91e650123064448&v=1614151242
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Tilkov.mp3
 description: Architektur muss man abhängig von der Zielgruppe betrachten.
-thumbnail: OOP.jpg
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-603283d91e650123064448&v=1614151242
+guests:
+- Lisa Schäfer
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Tilkov.mp3
 tags:
 - Live von der OOP
 - Architektur bewerten
+thumbnail: OOP.jpg
+title: Folge 45 - Stefan Tilkov - Software-Architektur für verschiedene Zielgruppen
+  - Live von der OOP mit Lisa Schäfer
+video: NBU4EZapeLQ
 ---
 
 Stefan Tilkov sieht Software-Architektur als entscheidenden

--- a/_posts/2021-02-11-folge46.md
+++ b/_posts/2021-02-11-folge46.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 46 - Bastian Spanneberg - Site Reliability Engineering - Live von der OOP
-layout: folge
-video: tICus5YmGfo
+description: Site Reliability Engineering ist ein anderer Ansatz für den Betrieb von
+  Anwendungen.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-6032846081402603578057&v=1614151242
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Spanneberg.mp3
-description: Site Reliability Engineering ist ein anderer Ansatz für den Betrieb von Anwendungen.
-thumbnail: OOP.jpg
 tags:
 - Live von der OOP
 - DevOps
 - Site Reliability Engineering
+thumbnail: OOP.jpg
+title: Folge 46 - Bastian Spanneberg - Site Reliability Engineering - Live von der
+  OOP
+video: tICus5YmGfo
 ---
 
 Bastian Spannebergs Arbeitgeber Instana hat als kleines StartUp begonnen, ist dann stark gewachsten und mittlerweile von IBM gekauft. Wir diskutieren Site Reliability Engineering als Konzept und wie es sich bei Instana auf dieser Reise verändert hat.


### PR DESCRIPTION
Add guest and moderator metadata for episodes 46, 45, 44, 43, 42, 41, 40, 39, 38, 37.

This PR addresses issue #60 - systematic addition of guest metadata to episode frontmatter.

Batch 17 of systematic guest metadata addition.
Processed 10 episode files.

Notable guests extracted:
- Episode 45: Lisa Schäfer
- Episode 42: Lisa Schäfer  
- Episode 39: Lisa Schäfer

Changes:
- Added 'guests' field with extracted guest names from episode titles
- Added 'moderators' field with ["Eberhard Wolff"]
- Used regex pattern matching to extract guests from "mit" patterns in titles

Part of systematic processing to add guest metadata to all episodes as requested in #60.