### PR TITLE
Add guest metadata: Episodes 36, 35, 34, 31, 30, 29, 28, 27, 26, 25 (Batch 18) - addressing #60

### DIFF
--- a/_posts/2020-11-13-folge025.md
+++ b/_posts/2020-11-13-folge025.md
@@ -1,12 +1,16 @@
 ---
-title: Folge 25 - Microservices, Transaktionen & Konsistenz
-layout: folge
-video: ok2x0bcKrLQ
+description: Microservices sind verteilte Systeme, so dass Transaktionen und Konsistenz
+  eine Herausforderung sind.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-5faeaccba5526717209651&v=1605283313
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/MicroservicesTransaktionenKonsistenz.mp3
-description: Microservices sind verteilte Systeme, so dass Transaktionen und Konsistenz eine Herausforderung sind.
-thumbnail: folge25.png
 tags: Microservices Konsistenz
+thumbnail: folge25.png
+title: Folge 25 - Microservices, Transaktionen & Konsistenz
+video: ok2x0bcKrLQ
 ---
 
 Microservices sind verteilte Systeme. Damit ist die Konsistenz der

--- a/_posts/2020-11-20-folge026.md
+++ b/_posts/2020-11-20-folge026.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 26 - Modularisierung
-layout: folge
-video: zkcX0D2h930
+description: Modularisierung ist ein klassisches Thema, das aber auch die Basis für
+  moderne Architekturen ist.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-5fb7c2616193c052084988&v=1605879218
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Modularisierung.mp3
-description: Modularisierung ist ein klassisches Thema, das aber auch die Basis für moderne Architekturen ist.
-thumbnail: folge26.png
 tags:
 - Modularisierung
 - Grundlagen
+thumbnail: folge26.png
+title: Folge 26 - Modularisierung
+video: zkcX0D2h930
 ---
 
 Nur mit Modularisierung kann man große Systeme entwickeln. Gerade durch Microservices gibt es wieder eine Diskussion zu diesem zentralen Konzept. In dieser Folge werden wir uns klassische Konzepte zur Modularisierung beispielsweise von Parnas anschauen und herausarbeiten, was man aus diesen Ansätzen für Architektur-Arbeit an modernen Systemen lernen kann.

--- a/_posts/2020-11-27-folge027.md
+++ b/_posts/2020-11-27-folge027.md
@@ -1,12 +1,17 @@
 ---
-title: Folge 27 - Architektur-Optionen für moderne Web Frontends mit Franziska Dessart, Joy Heron und Lucas Dohmen
-layout: folge
-video: fl0aEwvorQw
+description: Wir sprechen über verschiedene Architektur-Optionen für moderen Frontends.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-5fc10070677a6874244399&v=1606484605
+guests:
+- Franziska Dessart, Joy Heron und Lucas Dohmen
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/WebArchitekturOptionen.mp3
-description: Wir sprechen über verschiedene Architektur-Optionen für moderen Frontends. 
-thumbnail: folge27.png
 tag: Frontend
+thumbnail: folge27.png
+title: Folge 27 - Architektur-Optionen für moderne Web Frontends mit Franziska Dessart,
+  Joy Heron und Lucas Dohmen
+video: fl0aEwvorQw
 ---
 
 Schon in [Folge

--- a/_posts/2020-12-07-folge028.md
+++ b/_posts/2020-12-07-folge028.md
@@ -1,12 +1,17 @@
 ---
-title: Folge 28 - Der INNOQ Technology Day mit dem Technology-Day-Programm-Komitee
-layout: folge
-video: jnYFALvAgio
+description: Das Programm-Komitee erläutert die Idee der Konferenz und was den Technology
+  Day besonders macht.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-5fce72b8866c0650815247&v=1607368309
+guests:
+- dem Technology-Day-Programm-Komitee
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/INNOQTechnologyDay.mp3
-description: Das Programm-Komitee erläutert die Idee der Konferenz und was den Technology Day besonders macht.
-thumbnail: ITD.png
 tag: INNOQ Technology Day
+thumbnail: ITD.png
+title: Folge 28 - Der INNOQ Technology Day mit dem Technology-Day-Programm-Komitee
+video: jnYFALvAgio
 ---
 
 Der [INNOQ Technology Day](https://technologyday.innoq.com/) ist eine

--- a/_posts/2020-12-07-folge029.md
+++ b/_posts/2020-12-07-folge029.md
@@ -1,15 +1,21 @@
 ---
-title: Folge 29 - Sokratische Gespräche für Software-Architektur-Beratung und -Training mit Johannes Seitz - Live vom INNOQ Technology Day
-layout: folge
-video: s-SeVY12eAo
+description: Johannes Seitz erklärt sokratische Gespräche und wie sie bei Software-Architektur-Beratung
+  und -Training helfen können.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-5fce8113c2cab924296371&v=1607369505
+guests:
+- Johannes Seitz - Live vom INNOQ Technology Day
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/SokratischeGesprache.mp3
-description: Johannes Seitz erklärt sokratische Gespräche und wie sie bei Software-Architektur-Beratung und -Training helfen können.
-thumbnail: ITD.png
 tags:
 - Kommunikation
 - Sokratische Gespräche
 - INNOQ Technology Day
+thumbnail: ITD.png
+title: Folge 29 - Sokratische Gespräche für Software-Architektur-Beratung und -Training
+  mit Johannes Seitz - Live vom INNOQ Technology Day
+video: s-SeVY12eAo
 ---
 
 In dieser Folge diskutiert Johannes Seitz sokratische Gespräche. Das

--- a/_posts/2020-12-07-folge030.md
+++ b/_posts/2020-12-07-folge030.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 30 - Security mit Christoph Iserlohn - Live vom INNOQ Technology Day
-layout: folge
-video: 2mR56FDnoOc
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-5fce860972831973936715&v=1607370465
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Security.mp3
 description: Christoph Iserlohn erklärt wichtige Grundlagen von Security in Software-Systemen.
-thumbnail: ITD.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-5fce860972831973936715&v=1607370465
+guests:
+- Christoph Iserlohn - Live vom INNOQ Technology Day
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Security.mp3
 tags:
 - INNOQ Technology Day
 - Sicherheit
+thumbnail: ITD.png
+title: Folge 30 - Security mit Christoph Iserlohn - Live vom INNOQ Technology Day
+video: 2mR56FDnoOc
 ---
 
 Lisa Schäfer spricht mit Christoph Iserlohn über Sicherheit und was

--- a/_posts/2020-12-07-folge031.md
+++ b/_posts/2020-12-07-folge031.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 31 - DevOps und Team Topologies mit Anja Kammer - Live vom INNOQ Technology Day
-layout: folge
-video: VEpjcYY9k6c
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-5fce8946bbf0c449271811&v=160737139
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/DevOps.mp3
 description: Anja Kammer erklärt DevOps und Team Topologies
-thumbnail: ITD.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-5fce8946bbf0c449271811&v=160737139
+guests:
+- Anja Kammer - Live vom INNOQ Technology Day
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/DevOps.mp3
 tags:
 - INNOQ Technology Day
 - DevOps
 - Team Topologies
+thumbnail: ITD.png
+title: Folge 31 - DevOps und Team Topologies mit Anja Kammer - Live vom INNOQ Technology
+  Day
+video: VEpjcYY9k6c
 ---
 
 Anja Kammer erklärt in dieser Folge, warum und wie man keine DevOps

--- a/_posts/2021-01-08-folge34.md
+++ b/_posts/2021-01-08-folge34.md
@@ -1,14 +1,18 @@
 ---
-title: Episode 34 - Patrick Kua - Evolutionary Software Architecture
-layout: folge
-video: ttL7MiF8VZw
+description: Patrick Kua talks about how to architect a software system to support
+  evolution.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-6004381d827ee294705835&v=1610890304
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/PatrickKuaEvolutionaryArchitecture.mp3
-description: Patrick Kua talks about how to architect a software system to support evolution.
-thumbnail: folge34.png
 tags:
 - Evolutionary Software Architecture
 - English
+thumbnail: folge34.png
+title: Episode 34 - Patrick Kua - Evolutionary Software Architecture
+video: ttL7MiF8VZw
 ---
 
 Patrick Kua was CTO and Chief Scientist at N26 in Berlin and is now an

--- a/_posts/2021-01-15-folge35.md
+++ b/_posts/2021-01-15-folge35.md
@@ -1,13 +1,17 @@
 ---
-title: Folge 35 - André Neubauer - CTO = Chief Technical Debt Owner?
-layout: folge
-video: c4ljm7dqpgU
+description: André Neubauer spricht über technische Schulden als wichtiges Thema für
+  einen CTO.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-600472dd8c9b5096298234&v=1610904451
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/AndreNeubauerCTOChiefTechnicalDebtOwner.mp3
-description: André Neubauer spricht über technische Schulden als wichtiges Thema für einen CTO.
-thumbnail: folge35.jpg
 tags:
 - Technical Debt
+thumbnail: folge35.jpg
+title: Folge 35 - André Neubauer - CTO = Chief Technical Debt Owner?
+video: c4ljm7dqpgU
 ---
 
 Eine der größten Herausforderungen, denen sich Software-Entwickler und

--- a/_posts/2021-01-22-folge36.md
+++ b/_posts/2021-01-22-folge36.md
@@ -1,14 +1,18 @@
 ---
-title: Episode 36 - Simon Brown - C4 Architecture Model and Structurizr
-layout: folge
-video: YS0ySnnlyto
+description: Simon Brown talks about the C4 Architecture Model and Structrizr - a
+  tool to visualize C4 models.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-601127d209e1d341988897&v=1611738279
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/SimonBrownC4Structurizr.mp3
-description: Simon Brown talks about the C4 Architecture Model and Structrizr - a tool to visualize C4 models.
-thumbnail: folge36.jpg
 tags:
 - English
 - Architecture Management
+thumbnail: folge36.jpg
+title: Episode 36 - Simon Brown - C4 Architecture Model and Structurizr
+video: YS0ySnnlyto
 ---
 
 Simon Brown is the author of Software Architecture for Developers; a


### PR DESCRIPTION
Add guest and moderator metadata for episodes 36, 35, 34, 31, 30, 29, 28, 27, 26, 25.

This PR addresses issue #60 - systematic addition of guest metadata to episode frontmatter.

Batch 18 of systematic guest metadata addition.
Processed 10 episode files (skipped non-existent episodes 33, 32).

Notable guests extracted:
- Episode 31: Anja Kammer - Live vom INNOQ Technology Day
- Episode 30: Christoph Iserlohn - Live vom INNOQ Technology Day  
- Episode 29: Johannes Seitz - Live vom INNOQ Technology Day
- Episode 28: dem Technology-Day-Programm-Komitee
- Episode 27: Franziska Dessart, Joy Heron und Lucas Dohmen

Changes:
- Added 'guests' field with extracted guest names from episode titles
- Added 'moderators' field with ["Eberhard Wolff"]
- Used regex pattern matching to extract guests from "mit" patterns in titles

Part of systematic processing to add guest metadata to all episodes as requested in #60.