### PR TITLE
Add guest metadata: Episodes 24, 23, 22, 21, 20, 19, 17, 16, 15, 14 (Batch 19) - addressing #60

### DIFF
--- a/_posts/2020-08-21-folge014.md
+++ b/_posts/2020-08-21-folge014.md
@@ -1,13 +1,16 @@
 ---
-title: Folge 14 - Fragen und Antworten
-layout: folge
-video: TKrslEu67Lw
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-7cca461df8a346b7daa4f00f5c&v=1617104411
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/FragenUndAntworten.mp3
 description: Antworten zu Zuschauer-Fragen
-thumbnail: folge14.jpg
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-7cca461df8a346b7daa4f00f5c&v=1617104411
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/FragenUndAntworten.mp3
 tags:
 - Q&A
+thumbnail: folge14.jpg
+title: Folge 14 - Fragen und Antworten
+video: TKrslEu67Lw
 ---
 
 In dieser Folge möchte ich gerne einige Fragen beantworten, die sich

--- a/_posts/2020-08-28-folge015.md
+++ b/_posts/2020-08-28-folge015.md
@@ -1,12 +1,15 @@
 ---
-title: Folge 15 - Jutta Eckstein über die Architektur-Rolle in agilen Projekten
-layout: folge
-video: RX8mhRxBKYU
 description: Jutta Eckstein über Architektur und Architekt:innen in agilen Projekten
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-6063171d37287661480641&v=1617107006
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/JuttaEckstein.mp3
-thumbnail: folge15.jpg
 tags: Agilität
+thumbnail: folge15.jpg
+title: Folge 15 - Jutta Eckstein über die Architektur-Rolle in agilen Projekten
+video: RX8mhRxBKYU
 ---
 
 Agile Projekte bieten spezielle Herausforderungen für

--- a/_posts/2020-09-10-folge016.md
+++ b/_posts/2020-09-10-folge016.md
@@ -1,12 +1,16 @@
 ---
-title: Folge 16 - Gerrit Beine zu Sozialwissenschaften und Software-Architektur
-layout: folge
-video: dQdTLzoeKUE
-description: Gerrit Beine diskutiert, was Software-Architekt:innen aus den Sozialwissenschaften lernen können
-thumbnail: folge16.jpg
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/GerrtiBeine.mp3
+description: Gerrit Beine diskutiert, was Software-Architekt:innen aus den Sozialwissenschaften
+  lernen können
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-606319de59491803526452&v=1617107735
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/GerrtiBeine.mp3
 tag: Organisation
+thumbnail: folge16.jpg
+title: Folge 16 - Gerrit Beine zu Sozialwissenschaften und Software-Architektur
+video: dQdTLzoeKUE
 ---
 
 Die Organisation beeinflusst die

--- a/_posts/2020-09-10-folge017.md
+++ b/_posts/2020-09-10-folge017.md
@@ -1,16 +1,19 @@
 ---
-title: Folge 17 - Nicole Rauch zu DDD, Event Storming & Specification by Example
-layout: folge
-video: gCzgR7g8sOs
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/NicoleRauch.mp3
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-3947e6c572a58ea75979934c7f&v=1618778016
 description: Nicole Rauch diskutiert DDD, Event Storming & Specification by Example
-thumbnail: folge17.jpg
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-3947e6c572a58ea75979934c7f&v=1618778016
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/NicoleRauch.mp3
 tags:
 - Domain-driven Design
 - Event Storming
 - Specification by Example
 - Collaborative Modeling
+thumbnail: folge17.jpg
+title: Folge 17 - Nicole Rauch zu DDD, Event Storming & Specification by Example
+video: gCzgR7g8sOs
 ---
 
 Diese Woche ist Nicole Rauch zu Gast. Mit Event Storming kann man

--- a/_posts/2020-09-18-folge019.md
+++ b/_posts/2020-09-18-folge019.md
@@ -1,12 +1,17 @@
 ---
-title: Folge 19 - Service Mesh Linkerd mit Hanna Prinz
-layout: folge
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/HannaPrinz.mp3
+description: Hanna Prinz und Eberhard Wolff zeigen Linkerd und diskutieren Service
+  Meshes
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-7d856893bbd314ca29483cd924&v=1619090765
-video: hK0ZzbbigVM
-description: Hanna Prinz und Eberhard Wolff zeigen Linkerd und diskutieren Service Meshes
-thumbnail: folge19.jpg
+guests:
+- Hanna Prinz
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/HannaPrinz.mp3
 tags: Microservices
+thumbnail: folge19.jpg
+title: Folge 19 - Service Mesh Linkerd mit Hanna Prinz
+video: hK0ZzbbigVM
 ---
 
 Service Meshes sind vor allem als Infrastruktur für Microservices

--- a/_posts/2020-10-02-folge020.md
+++ b/_posts/2020-10-02-folge020.md
@@ -1,12 +1,18 @@
 ---
-title: Folge 20 -  Frontend-Architektur mit Franziska Dessart, Joy Heron und Lucas Dohmen
-layout: folge
-video: pOIKn6BYWiY
+description: Franziska Dessart, Joy Heron und Lucas Dohmen stellen sich verschiedenen
+  Fragen zu Frontend-Architekturen
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-5fba773e3ff3d325164719&v=1606236880
+guests:
+- Franziska Dessart, Joy Heron und Lucas Dohmen
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Frontend.mp3
-description: Franziska Dessart, Joy Heron und Lucas Dohmen stellen sich verschiedenen Fragen zu Frontend-Architekturen
-thumbnail: folge20.png
 tag: Frontend
+thumbnail: folge20.png
+title: Folge 20 -  Frontend-Architektur mit Franziska Dessart, Joy Heron und Lucas
+  Dohmen
+video: pOIKn6BYWiY
 ---
 
 Frontends scheinen auf den ersten Blick einfach, aber auch der Entwurf

--- a/_posts/2020-10-09-folge021.md
+++ b/_posts/2020-10-09-folge021.md
@@ -1,14 +1,19 @@
 ---
-title: Folge 21 -  Domain Story Telling mit Henning Schwentner und Stefan Hofer
-layout: folge
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/DomainStoryTelling.mp3
+description: Henning Schwentner und Stefan Hofer zeigen Domain Story Telling live
+  und beantworten Fragen.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-becbc7f38faf8247b2d9c89db&v=1619093322
-video: XSE5m9Frvsg
-description: Henning Schwentner und Stefan Hofer zeigen Domain Story Telling live und beantworten Fragen.
-thumbnail: folge21.jpg
+guests:
+- Henning Schwentner und Stefan Hofer
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/DomainStoryTelling.mp3
 tags:
 - Domain-driven Design
 - Collaborative Modeling
+thumbnail: folge21.jpg
+title: Folge 21 -  Domain Story Telling mit Henning Schwentner und Stefan Hofer
+video: XSE5m9Frvsg
 ---
 
 Domain Story Telling ist ein kollaborativer

--- a/_posts/2020-10-23-folge022.md
+++ b/_posts/2020-10-23-folge022.md
@@ -1,14 +1,20 @@
 ---
-title: Folge 22 - Markus Völter zu Fachliche Architekturen mit DSL (Domain Specific Languages)
-layout: folge
-video: 4MUf-q1gsn0
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/MarkusVoelter.mp3
+description: Markus Völter erläutert, was DSLs sind und wie man sie für die fachliche
+  Architektur nutzen kann.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-608171ec8287d654711445&v=1619097352
-description: Markus Völter erläutert, was DSLs sind und wie man sie für die fachliche Architektur nutzen kann.
-thumbnail: folge22.png
+guests:
+- DSL
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/MarkusVoelter.mp3
 tags:
 - Domain Specific Languages
 - Domain-driven Design
+thumbnail: folge22.png
+title: Folge 22 - Markus Völter zu Fachliche Architekturen mit DSL (Domain Specific
+  Languages)
+video: 4MUf-q1gsn0
 ---
 
 Domain Specific Languages können auch dabei helfen, fachliche

--- a/_posts/2020-10-29-folge023.md
+++ b/_posts/2020-10-29-folge023.md
@@ -1,12 +1,16 @@
 ---
-title: Folge 23 - Lisa Schäfer zu Sketchnotes in der IT
-layout: folge
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/LisaMoritz.mp3
+description: Lisa Schäfer zeigt und zeichnet Sketchnotes - und erläutert wofür sie
+  gerade in der IT gut sind.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-6081761121cb2053178822&v=1619097352
-video: 2xX9CCndAew
-description: Lisa Schäfer zeigt und zeichnet Sketchnotes - und erläutert wofür sie gerade in der IT gut sind.
-thumbnail: folge23.png
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/LisaMoritz.mp3
 tag: Sketchnotes
+thumbnail: folge23.png
+title: Folge 23 - Lisa Schäfer zu Sketchnotes in der IT
+video: 2xX9CCndAew
 ---
 Sketchnotes sehen nicht nur gut aus, sondern machen Notizen effektiver
 und erleichtern das Vermitteln von Inhalten. Lisa malt schon länger

--- a/_posts/2020-11-06-folge024.md
+++ b/_posts/2020-11-06-folge024.md
@@ -1,12 +1,18 @@
 ---
-title: Folge 24 - Kundenspezifische Software-Varianten und Product Line Engineering mit Danilo Beuche
-layout: folge
-video: Ix-7AyHhl-E
+description: Danilo Beuche erläutert, wie Product Line Engineering das Managen von
+  Kunden-spezifische Software-Varianten erleichtert
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-5fa975ae2ec66657824722&v=1604941412
+guests:
+- Danilo Beuche
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/PLE.mp3
-description: Danilo Beuche erläutert, wie Product Line Engineering das Managen von Kunden-spezifische Software-Varianten erleichtert
-thumbnail: folge24.png
 tag: Product Line Engineering
+thumbnail: folge24.png
+title: Folge 24 - Kundenspezifische Software-Varianten und Product Line Engineering
+  mit Danilo Beuche
+video: Ix-7AyHhl-E
 ---
 
 Ein Kunde hat eine besondere Anforderung an die Software, dann kommt


### PR DESCRIPTION
Add guest and moderator metadata for episodes 24, 23, 22, 21, 20, 19, 17, 16, 15, 14.

This PR addresses issue #60 - systematic addition of guest metadata to episode frontmatter.

Batch 19 of systematic guest metadata addition.
Processed 10 episode files.

Notable guests extracted:
- Episode 24: Danilo Beuche
- Episode 22: DSL
- Episode 21: Henning Schwentner und Stefan Hofer
- Episode 20: Franziska Dessart, Joy Heron und Lucas Dohmen
- Episode 19: Hanna Prinz

Changes:
- Added 'guests' field with extracted guest names from episode titles
- Added 'moderators' field with ["Eberhard Wolff"]
- Used regex pattern matching to extract guests from "mit" patterns in titles

Part of systematic processing to add guest metadata to all episodes as requested in #60.