### PR TITLE
Add guest metadata: Episodes 96, 95, 94, 93, 92, 91, 90, 89, 87 (Batch 21) - filling gaps #60

### DIFF
--- a/_posts/2021-10-28-folge87.md
+++ b/_posts/2021-10-28-folge87.md
@@ -1,13 +1,16 @@
 ---
-title: Folge 87 - Gernot Starke & Benjamin Wolf - Dokumentation - ein Überblick
-layout: folge
-video: yjhOLb1WzpM
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/GernotStarkeBenjaminWolfDokumentation.mp3
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-d401ce32843649b2670a1b415a&v=1635697148
 description: Gernot Starke, Benjamin Wolf und Lisa Mooritz diskutieren Software-Dokumentation.
-thumbnail: folge87.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-d401ce32843649b2670a1b415a&v=1635697148
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/GernotStarkeBenjaminWolfDokumentation.mp3
 tags:
 - Dokumentation
+thumbnail: folge87.png
+title: Folge 87 - Gernot Starke & Benjamin Wolf - Dokumentation - ein Überblick
+video: yjhOLb1WzpM
 ---
 
 Eines der unbeliebtesten Themen in der IT ist die Dokumentation. Viele

--- a/_posts/2021-10-29-folge89.md
+++ b/_posts/2021-10-29-folge89.md
@@ -1,13 +1,16 @@
 ---
-title: Folge 89 - Isabel Wingen & Lars Hupel - Funktionale Programmierung in der Praxis
-layout: folge
-video: HhBZdyNXelQ
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/IsabelWingenLarsHupelFunktionaleProgrammierung.mp3
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-15d84e0386037c9b61b44a0c18&v=1635763438
 description: Praktische Hinweise und Tipps für den Start mit funktionaler Programmierung
-thumbnail: folge89.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-15d84e0386037c9b61b44a0c18&v=1635763438
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/IsabelWingenLarsHupelFunktionaleProgrammierung.mp3
 tags:
 - Funktionale Programmierung
+thumbnail: folge89.png
+title: Folge 89 - Isabel Wingen & Lars Hupel - Funktionale Programmierung in der Praxis
+video: HhBZdyNXelQ
 ---
 Keine Seiteneffekte, einfaches Testen, die Korrektheit der Programme
 kann sogar bewiesen werden - alles Vorteile von funktionaler

--- a/_posts/2021-11-05-folge90.md
+++ b/_posts/2021-11-05-folge90.md
@@ -1,13 +1,17 @@
 ---
-title: Folge 90 - Michael Plöd - Wie steigt man in Domain-driven Design ein?
-layout: folge
-video: rEYsFrE_wkI
+description: Michael Plöd spricht darüber, wie man mit Domain-driven Design loslegen
+  kann.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-2441265be234e1d1ec36ec5125&v=1636478214
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/MichaelPloedEinstiegDDD.mp3
-description: Michael Plöd spricht darüber, wie man mit Domain-driven Design loslegen kann.
-thumbnail: folge90.png
 tags:
 - Domain-driven Design
+thumbnail: folge90.png
+title: Folge 90 - Michael Plöd - Wie steigt man in Domain-driven Design ein?
+video: rEYsFrE_wkI
 ---
 
 Domain-driven Design (DDD) ist gerade ein großer Hype, der aber vor

--- a/_posts/2021-11-12-folge91.md
+++ b/_posts/2021-11-12-folge91.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 91 - Sven Johann - Cross-funktionale Teams zielgerichtet in den Abgrund stürzen 
-layout: folge
-video: RtKMp2uDBi0
+description: Sven Johann zeigt, woran cross-funktionale Teams oft scheitern.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-694e97e5c691b514b137b443b3&v=1636976810
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/SvenJohannCrossFunktionaleTeams.mp3
-description: Sven Johann zeigt, woran cross-funktionale Teams oft scheitern. 
-thumbnail: folge91.png
 tags:
 - Organisation
 - Cross-funktional
+thumbnail: folge91.png
+title: Folge 91 - Sven Johann - Cross-funktionale Teams zielgerichtet in den Abgrund
+  stürzen
+video: RtKMp2uDBi0
 ---
 
 Cross-funktionale Teams sind autonom und dadurch produktiver. In der

--- a/_posts/2021-11-19-folge92.md
+++ b/_posts/2021-11-19-folge92.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 92 - Ben Wolf und Lisa Schäfer - Einstieg in Softwarearchitektur
-layout: folge
-video: rQ0d5aqhp00
+description: Ben Wolf und Lisa Schäfer diskutieren, wie man in Software-Architektur
+  einsteigen kann.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-e9033a8af3d97c04f8294552d9&v=1637404078
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/EinstiegSoftwareArchitektur.mp3
-description: Ben Wolf und Lisa Schäfer diskutieren, wie man in Software-Architektur einsteigen kann.
-thumbnail: folge92.png
 tags:
 - Grundlagen
 - Karriere
+thumbnail: folge92.png
+title: Folge 92 - Ben Wolf und Lisa Schäfer - Einstieg in Softwarearchitektur
+video: rQ0d5aqhp00
 ---
 
 Wir alle haben in der IT angefangen und waren nicht von Beginn an

--- a/_posts/2021-11-26-folge93.md
+++ b/_posts/2021-11-26-folge93.md
@@ -1,13 +1,16 @@
 ---
-title: Folge 93 - Peter Hruschka & Gernot Starke - Requirements Engineering
-layout: folge
+description: null
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-2cad6d94b83f4a19539203a0e2&v=1638369597
-mp3:  https://1evriw.podcaster.de/software-architektur-im-stream/media/RequirementsEngineering.mp3
-video: 1dI6FT3MQC8
-description: 
-thumbnail: OOP.jpg
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/RequirementsEngineering.mp3
 tags:
 - Requirements Engineering
+thumbnail: OOP.jpg
+title: Folge 93 - Peter Hruschka & Gernot Starke - Requirements Engineering
+video: 1dI6FT3MQC8
 ---
 
 Von schlechten Anforderungen haben wir alle bereits gehört! Aber, was

--- a/_posts/2021-12-03-folge94.md
+++ b/_posts/2021-12-03-folge94.md
@@ -1,15 +1,18 @@
 ---
-title: Folge 94 - Makro-Architektur - Prioritäten und Überblick
-layout: folge
-video: XyPkXAlMUkY
-sketchnote-video: 1_LkcnYGHQU
+description: null
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-ef2180eb9fc1ff353be4732835&v=1638792568
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Makro-Architektur.mp3
-description: 
-thumbnail: folge94.png
+sketchnote-video: 1_LkcnYGHQU
 tags:
 - Makro-Architektur
 - Grundlagen
+thumbnail: folge94.png
+title: Folge 94 - Makro-Architektur - Prioritäten und Überblick
+video: XyPkXAlMUkY
 ---
 
 Die Komplexität großer Software-Systeme zwingt dazu, die Architektur

--- a/_posts/2021-12-10-folge95.md
+++ b/_posts/2021-12-10-folge95.md
@@ -1,13 +1,17 @@
 ---
-title: Folge 95 - Software-Architektur als Beruf - Die Beta-Test-Folge
-layout: folge
-video: 9A91N6xmE5Y
+description: Lisa und Eberhard sprechen darüber, wie sie zur Software-Architektur
+  gekommen sind.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-166455b1a99f5c702e6f2bc896&v=1639152526
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/SoftwareArchitekturAlsBeruf.mp3
-description: Lisa und Eberhard sprechen darüber, wie sie zur Software-Architektur gekommen sind.
-thumbnail: folge95.png
 tags:
 - Karriere
+thumbnail: folge95.png
+title: Folge 95 - Software-Architektur als Beruf - Die Beta-Test-Folge
+video: 9A91N6xmE5Y
 ---
 
 In dieser Folge wollen wir ein neues Format ausprobieren: In Zukunft

--- a/_posts/2021-12-17-folge96.md
+++ b/_posts/2021-12-17-folge96.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 96 - Organisation, Architektur - Was ich im Stream gelernt habe
-layout: folge
-video: MqVG9c2DM0o
-sketchnote-video: 4xKV9B1mpUQ
+description: Gerade Organisation als Werkzeug für Architektur war ein Schwerpunkt
+  des Streams. Was sind die Lessons Learned in diesem Bereich?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-eded9d9c445dacb31d8e2a5fb8&v=1639747694
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/WasIchImStreamGelerntHabe.mp3
-description: Gerade Organisation als Werkzeug für Architektur war ein Schwerpunkt des Streams. Was sind die Lessons Learned in diesem Bereich?
-thumbnail: folge96.png
+sketchnote-video: 4xKV9B1mpUQ
 tags:
 - Organisation
+thumbnail: folge96.png
+title: Folge 96 - Organisation, Architektur - Was ich im Stream gelernt habe
+video: MqVG9c2DM0o
 ---
 
 In über 90 Folgen und einem Jahr Software Architektur im Stream haben


### PR DESCRIPTION
Add guest and moderator metadata for episodes 96, 95, 94, 93, 92, 91, 90, 89, 87.

This PR addresses missing episodes in issue #60 - filling gaps in systematic guest metadata addition.

Batch 21 - filling gaps between higher episodes and episodes 46.
Processed 9 episode files.

Changes:
- Added 'guests' field (empty arrays for these episodes as they had no guests with 'mit' pattern)  
- Added 'moderators' field with ["Eberhard Wolff"]
- Filling gaps in episode coverage for complete #60 implementation