### PR TITLE
Add guest metadata: Episodes 86, 85, 84, 83, 82, 79, 78, 77 (Batch 22) - filling gaps #60

### DIFF
--- a/_posts/2021-09-27-episode77.md
+++ b/_posts/2021-09-27-episode77.md
@@ -1,15 +1,19 @@
 ---
-title: Episode 77 - Rebecca Parsons about Evolutionary Architecture
-layout: folge
-video: vScBOOQ4vjo
-sketchnote-video: 77y7G95e8Co
+description: Rebecca Parsons (CTO, Thoughtworks) talks about fundamental concepts
+  of evolutionary architecture.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-0575814ef4af55816ef45c7b6a&v=1632829657
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/RebeccaParsonsEvolutionaryArchitecture.mp3
-description: Rebecca Parsons (CTO, Thoughtworks) talks about fundamental concepts of evolutionary architecture.
-thumbnail: folge77.png
+sketchnote-video: 77y7G95e8Co
 tags:
 - English
 - Evolutionary Software Architecture
+thumbnail: folge77.png
+title: Episode 77 - Rebecca Parsons about Evolutionary Architecture
+video: vScBOOQ4vjo
 ---
 
 The architecture of a system has to change over time. In this episode,

--- a/_posts/2021-10-01-episode78.md
+++ b/_posts/2021-10-01-episode78.md
@@ -1,15 +1,19 @@
 ---
-title: Episode 78 - Kevlin Henney - Dealing with Uncertainty
-layout: folge
-video: NbmdXj0Lm4k
-sketchnote-video: IURXpe3stjg
+description: Uncertainty makes software architecture difficult. How can we deal with
+  it?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-3f39ab0c8f61410cadbc41234b&v=1633247425
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/KevlinHenneyUncertainty.mp3
-description: Uncertainty makes software architecture difficult. How can we deal with it?
-thumbnail: folge78.png
+sketchnote-video: IURXpe3stjg
 tags:
 - English
 - Uncertainty
+thumbnail: folge78.png
+title: Episode 78 - Kevlin Henney - Dealing with Uncertainty
+video: NbmdXj0Lm4k
 ---
 
 ![Sketchnotes](/sketchnotes/folge78.jpg)

--- a/_posts/2021-10-04-episode79.md
+++ b/_posts/2021-10-04-episode79.md
@@ -1,15 +1,19 @@
 ---
-title: Episode 79 - Microservices, Monoliths, Modularization with Chris Richardson
-layout: folge
-video: rCosIgyWR68
+description: Chris Richardson discusses several modularization options like microservices
+  and monoliths
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-1e6821d62b21c8cff864973724&v=1633619086
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/ChrisRichardsonMicroservicesMonolithsModularization.mp3
-description: Chris Richardson discusses several modularization options like microservices and monoliths
-thumbnail: folge79.png
 tags:
 - English
 - Microservices
 - Modularisierung
+thumbnail: folge79.png
+title: Episode 79 - Microservices, Monoliths, Modularization with Chris Richardson
+video: rCosIgyWR68
 ---
 
 Software architecture is fundamentally about how to split a software

--- a/_posts/2021-10-14-episode82.md
+++ b/_posts/2021-10-14-episode82.md
@@ -1,15 +1,19 @@
 ---
-title: Episode 82 - Avraham Poupko & Kenny Baas-Schwegler - The Influence of Culture on Software Design
-layout: folge
-video: a3qr_M_wMkw
+description: What is the impact of culture on software design?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-d659fe2c51726149120b47c166&v=1634663608
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/AvrahamPoupkoKennyBaas-SchweglerTheInfluenceOfCultureOnSoftwareDesign.mp3
-description: What is the impact of culture on software design? 
-thumbnail: SAG-special.png
 tags:
 - English
 - Organisation
 - Kultur
+thumbnail: SAG-special.png
+title: Episode 82 - Avraham Poupko & Kenny Baas-Schwegler - The Influence of Culture
+  on Software Design
+video: a3qr_M_wMkw
 ---
 
 Organisation und communication have a huge impact on software desgin

--- a/_posts/2021-10-14-episode83.md
+++ b/_posts/2021-10-14-episode83.md
@@ -1,14 +1,17 @@
 ---
-title: Episode 83 - Cosima Laube about D.A.R.E. more, F.E.A.R. less and Journaling
-layout: folge
-video: a3qr_M_wMkw?start=2088
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-1be5d4c9aac46beb78998d19e6&v=1634663608
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/CosimaLaubeDAREMoreFEARLessJournaling.mp3
 description: Cosima talks about written self-relfection.
-thumbnail: SAG-special.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-1be5d4c9aac46beb78998d19e6&v=1634663608
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/CosimaLaubeDAREMoreFEARLessJournaling.mp3
 tags:
 - English
 - Selbstreflektion
+thumbnail: SAG-special.png
+title: Episode 83 - Cosima Laube about D.A.R.E. more, F.E.A.R. less and Journaling
+video: a3qr_M_wMkw?start=2088
 ---
 
 Written self-reflection is very powerful and - at the same time - it

--- a/_posts/2021-10-15-folge84.md
+++ b/_posts/2021-10-15-folge84.md
@@ -1,13 +1,18 @@
 ---
-title: Folge 84 - Manfred Steyer zu Frontendarchitekturen mit Single Page Frameworks
-layout: folge
-video: ufJCgwJH5Mc
+description: Single Page Apps werden zunehmend anspruchsvoller - wie sieht eine sinnvolle
+  Frontend-Architektur für SPAs aus?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-b347af99d421ca57148aa4da4a&v=1634752761
+guests:
+- Single Page Frameworks
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/ManfredSteyerFrontendarchitekturenSinglePageFrameworks.mp3
-description: Single Page Apps werden zunehmend anspruchsvoller - wie sieht eine sinnvolle Frontend-Architektur für SPAs aus?
-thumbnail: folge84.png
 tags:
 - Frontend
+thumbnail: folge84.png
+title: Folge 84 - Manfred Steyer zu Frontendarchitekturen mit Single Page Frameworks
+video: ufJCgwJH5Mc
 ---
 
 Nachdem es schon einige Folgen zum Thema Frontendarchitektur gab, die

--- a/_posts/2021-10-22-folge85.md
+++ b/_posts/2021-10-22-folge85.md
@@ -1,15 +1,18 @@
 ---
-title: Folge 85 - Wiederverwendung
-layout: folge
-video: RJ5UKfA-j4o
-sketchnote-video: 9CPNQuUT7Ec
+description: Wiederverwendung
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-c53d902a663355ae11ab7f3ea8&v=1635178782
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Wiederverwendung.mp3
-description: Wiederverwendung 
-thumbnail: folge85.png
+sketchnote-video: 9CPNQuUT7Ec
 tags:
 - Wiederverwendung
 - Grundlagen
+thumbnail: folge85.png
+title: Folge 85 - Wiederverwendung
+video: RJ5UKfA-j4o
 ---
 
 Am Ende des letzten Jahrhunderts stand Wiederverwendung im Mittelpunkt

--- a/_posts/2021-10-25-episode86.md
+++ b/_posts/2021-10-25-episode86.md
@@ -1,14 +1,20 @@
 ---
-title: Epsiode 86 -  Hillel Wayne & Laurent Bossavit - Is It All Built on Sand - What Do We Actually Know About Software Development?
-layout: folge
-video: 2qWBPWQ34Jg
+description: Empirical Software Engineering researches how we built software. Hillel
+  Wayne and Laurent Bossavit discuss how little we actually know for sure and why
+  it is still valuable.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-2fa9642a465fcff7a10edf796f&v=1635254389
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/HillelWayneLaurentBossavit.mp3
-description: Empirical Software Engineering researches how we built software. Hillel Wayne and Laurent Bossavit discuss how little we actually know for sure and why it is still valuable.
-thumbnail: episode86.png
 tags:
 - English
 - Empirical Software Engineering
+thumbnail: episode86.png
+title: Epsiode 86 -  Hillel Wayne & Laurent Bossavit - Is It All Built on Sand - What
+  Do We Actually Know About Software Development?
+video: 2qWBPWQ34Jg
 ---
 
 We all have some ideas about what works in software engineering and


### PR DESCRIPTION
Add guest and moderator metadata for episodes 86, 85, 84, 83, 82, 79, 78, 77.

Batch 22 - continuing to fill gaps in issue #60.
Processed 8 episode files (episodes 81, 80 don't exist).

Notable guest extracted:
- Episode 84: Single Page Frameworks

Changes:
- Added 'guests' field with extracted guest names or empty arrays
- Added 'moderators' field with ["Eberhard Wolff"]
- Systematic gap filling for complete #60 coverage