### PR TITLE
Add guest metadata: Episodes 245-236 (Batch 23) - filling gaps #60

### DIFF
--- a/_posts/2024-10-25-episode236.md
+++ b/_posts/2024-10-25-episode236.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 236 - Code Retreat live - mit Marco Emrich
-layout: folge
-video: WksUB0pY3Ro
-peertube: https://tube.tchncs.de/videos/embed/1b9c1650-8e9f-42f8-bb9d-ca28e9c5310b
+description: Code-Retreats bieten ein Übungsfeld für Test-driven Development, Pair
+  Programming, Refactoring - wir sprechen drüber und zeigen es live.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-87d0e03c380c6b84ad79c4dfe&v=1729871087
+guests:
+- Marco Emrich
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/download/Code_Retreat_live_-_mit_Marco_Emrich.mp3
-description: Code-Retreats bieten ein Übungsfeld für Test-driven Development, Pair Programming, Refactoring - wir sprechen drüber und zeigen es live.
-thumbnail: episode236.png
+peertube: https://tube.tchncs.de/videos/embed/1b9c1650-8e9f-42f8-bb9d-ca28e9c5310b
 tags:
 - Code Retreat
 - Refactoring
+thumbnail: episode236.png
+title: Folge 236 - Code Retreat live - mit Marco Emrich
+video: WksUB0pY3Ro
 ---
 
 Ein Code Retreat ist eine ganztägige Veranstaltung für

--- a/_posts/2024-10-30-episode237.md
+++ b/_posts/2024-10-30-episode237.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 237 - Warum ist Software(-Architektur) eigentlich immer so schlecht?
-layout: folge
-video: ahyHUTMAqoY
-peertube: https://tube.tchncs.de/videos/embed/6c79df9d-f040-4077-8326-0060cc71de14
+description: Wartbarkeit und Code-Qualität lassen oft zu wünschen übrig - warum und
+  was können wir tun?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-925480e5409ee3ec91a6872a7e&v=1730303290
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/download/Warum_ist_Software_Architektur_so_schlecht.mp3
-description: Wartbarkeit und Code-Qualität lassen oft zu wünschen übrig - warum und was können wir tun?
-thumbnail: episode237.png
+peertube: https://tube.tchncs.de/videos/embed/6c79df9d-f040-4077-8326-0060cc71de14
 tags:
 - Technical Debt
+thumbnail: episode237.png
+title: Folge 237 - Warum ist Software(-Architektur) eigentlich immer so schlecht?
+video: ahyHUTMAqoY
 ---
 
 Zu oft ist die Code-Qualität von Software schlecht, was vor allem die

--- a/_posts/2024-11-07-episode238.md
+++ b/_posts/2024-11-07-episode238.md
@@ -1,16 +1,20 @@
 ---
-title: Episode 238 - Learning Systems Thinking with Diana Montalion and Lisa Schäfer
-layout: folge
-video: 07IYACU8t-E
-peertube: https://tube.tchncs.de/videos/embed/9c1ad801-5330-43ea-8ae9-65d96914f173
+description: Diana Montalion talks about systems thinking to solve out often systemic
+  challenges.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-c2457e6aed37353b134f86b608&v=1731017511
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/download/Learning_Systems_Thinking_with_Diana_Montalion_and_Lisa_Moritz.mp3
-description: Diana Montalion talks about systems thinking to solve out often systemic challenges.
-thumbnail: episode238.png
+peertube: https://tube.tchncs.de/videos/embed/9c1ad801-5330-43ea-8ae9-65d96914f173
 tags:
 - English
 - Systems Thinking
 - Live from Software Architekcture Gathering
+thumbnail: episode238.png
+title: Episode 238 - Learning Systems Thinking with Diana Montalion and Lisa Schäfer
+video: 07IYACU8t-E
 ---
 
 We already learnt about nonlinear thinking in [episode

--- a/_posts/2024-11-08-episode239.md
+++ b/_posts/2024-11-08-episode239.md
@@ -1,15 +1,21 @@
 ---
-title: Folge 239 - Was ist (Einzel-)Coaching und wie nützt es Techies? mit Cosima Laube und Lisa Schäfer
-layout: folge
-video: gLcdgEBOoAA
-peertube: https://tube.tchncs.de/videos/embed/829f7565-9a55-495d-b9f6-342821893e66
+description: Wie hilft Einzelcoaching als besondere Form des Coaching Techies? Wie
+  können Coaching-Werkzeuge in der alltäglichen Arbeit unterstützen?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-2440dc5af5f5e8d5b34bd19894&v=1731182459
+guests:
+- Cosima Laube und Lisa Schäfer
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/download/Was_ist_Einzel-Coaching_und_wie_nuetzt_es_Techies.mp3
-description: Wie hilft Einzelcoaching als besondere Form des Coaching Techies? Wie können Coaching-Werkzeuge in der alltäglichen Arbeit unterstützen?
-thumbnail: episode239.png
+peertube: https://tube.tchncs.de/videos/embed/829f7565-9a55-495d-b9f6-342821893e66
 tags:
 - Coaching
 - Live from Software Architecture Gatheringxs
+thumbnail: episode239.png
+title: Folge 239 - Was ist (Einzel-)Coaching und wie nützt es Techies? mit Cosima
+  Laube und Lisa Schäfer
+video: gLcdgEBOoAA
 ---
 
 Cosima und Lisa sprechen über Einzelcoaching. Was ist das überhaupt

--- a/_posts/2024-11-18-episode240.md
+++ b/_posts/2024-11-18-episode240.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 240 - Domain-Driven Design - Ein vollständiges Beispiel 1/2
-layout: folge
-video: VlPfO7pah8U
-peertube: https://tube.tchncs.de/videos/embed/c7511c15-f264-4a39-8edc-7b082b549139
+description: Ein Beispiel für DDD-Techniken wie Bounded Context, Core Domain, Event
+  Storming oder Team Topologies
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-7de1329602a07f8e4dcaa3130b&v=1731947570
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/download/Domain-Driven_Design_Ein_vollstaendiges_Beispiel_1.mp3
-description: Ein Beispiel für DDD-Techniken wie Bounded Context, Core Domain, Event Storming oder Team Topologies
-thumbnail: episode240.png
+peertube: https://tube.tchncs.de/videos/embed/c7511c15-f264-4a39-8edc-7b082b549139
 tags:
 - Domain-driven Design
+thumbnail: episode240.png
+title: Folge 240 - Domain-Driven Design - Ein vollständiges Beispiel 1/2
+video: VlPfO7pah8U
 ---
 
 Was bedeutet es eigentlich, Domain-driven Design (DDD) umzusetzen?

--- a/_posts/2024-11-22-episode241.md
+++ b/_posts/2024-11-22-episode241.md
@@ -1,18 +1,22 @@
 ---
-title: Folge 241 - Domain-Driven Design - Ein vollständiges Beispiel 2/2
-layout: folge
-video: ofvhk1fuPr8
-peertube: https://tube.tchncs.de/videos/embed/51f389c7-d44c-480f-a61c-13c29fa1aa1b
+description: Ein Beispiel für DDD-Techniken wie taktisches Design, CQRS, Event Sourcing,
+  hexagonale Architektur
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-cf4a9c68b9a593f85282c5d2c3&v=1732283900
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/download/Domain-Driven_Design_Ein_vollstaendiges_Beispiel_2.mp3
-description: Ein Beispiel für DDD-Techniken wie taktisches Design, CQRS, Event Sourcing, hexagonale Architektur
-thumbnail: episode241.png
+peertube: https://tube.tchncs.de/videos/embed/51f389c7-d44c-480f-a61c-13c29fa1aa1b
 tags:
 - Domain-driven Design
 - CQRS
 - Event Sourcing
 - Events
 - Hexagonale Architektur
+thumbnail: episode241.png
+title: Folge 241 - Domain-Driven Design - Ein vollständiges Beispiel 2/2
+video: ofvhk1fuPr8
 ---
 
 Was bedeutet es eigentlich, Domain-driven Design (DDD) umzusetzen?

--- a/_posts/2024-11-29-episode242.md
+++ b/_posts/2024-11-29-episode242.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 242 - Generative AI Meets Software Architecture mit Ralf D. Müller
-layout: folge
-video: 1zOVe37yvKM
-peertube: https://tube.tchncs.de/videos/embed/4dcffaa3-9500-4586-a74e-2ffcc9e36289
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-937f6c213c6315897dc9270e33&v=1732890294
-mp3: https://1evriw.podcaster.de/download/Generative_AI_Meets_Software_Architecture_mit_Ralf_und_Eberhard.mp3
 description: Eberhard und Ralf sprechen über den Einfluss von KI auf Software-Entwicklung
-thumbnail: episode242.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-937f6c213c6315897dc9270e33&v=1732890294
+guests:
+- Ralf D. Müller
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/download/Generative_AI_Meets_Software_Architecture_mit_Ralf_und_Eberhard.mp3
+peertube: https://tube.tchncs.de/videos/embed/4dcffaa3-9500-4586-a74e-2ffcc9e36289
 tags:
 - Künstliche Intelligenz
+thumbnail: episode242.png
+title: Folge 242 - Generative AI Meets Software Architecture mit Ralf D. Müller
+video: 1zOVe37yvKM
 ---
 
 Generative KI und Large Language Models sind in aller Munde - aber wie

--- a/_posts/2024-12-06-episode243.md
+++ b/_posts/2024-12-06-episode243.md
@@ -1,16 +1,21 @@
 ---
-title: Folge 243 - Process Orchestration, BPMN und Workflows mit Bernd Rücker
-layout: folge
-video: ItRopNk6avk
-peertube: https://tube.tchncs.de/videos/embed/036ce058-a314-47ec-ad0d-fe730fcdb6b8
+description: Wir sprechen über Einsatzkontexte von Workflow Engines, Orchestration,
+  Choreographie
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-ffc30d4cb7de49e67c87e4f164&v=1733496100
+guests:
+- Bernd Rücker
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/download/Process_Orchestration-_BPMN_und_Workflows_mit_Bernd_Ruecker.mp3
-description: Wir sprechen über Einsatzkontexte von Workflow Engines, Orchestration, Choreographie
-thumbnail: episode243.png
+peertube: https://tube.tchncs.de/videos/embed/036ce058-a314-47ec-ad0d-fe730fcdb6b8
 tags:
 - Process Orchestration
 - BPMN
 - Workflow
+thumbnail: episode243.png
+title: Folge 243 - Process Orchestration, BPMN und Workflows mit Bernd Rücker
+video: ItRopNk6avk
 ---
 
 Was steckt hinter Begriffen wie Workflow Engine, Process Orchestration

--- a/_posts/2024-12-10-episode244.md
+++ b/_posts/2024-12-10-episode244.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 244 - IT im Jahr 2034 – Wo wollen wir hin? 
-layout: folge
-video: 7OaTOhk0vCE
-peertube: https://tube.tchncs.de/videos/embed/6b3e1678-975b-4f2d-b128-36ad924dfa46
+description: Zum zehnjährigen Jubiläum der IT-Tage diskutieren wir IT 2034 mit Input
+  der Besucher:innen der IT-Tage.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-78fe5aa921eaa008df32370407&v=1734016508
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/download/IT_im_Jahr_2034_-_Wo_wollen_wir_hin.mp3
-description: Zum zehnjährigen Jubiläum der IT-Tage diskutieren wir IT 2034 mit Input der Besucher:innen der IT-Tage. 
-thumbnail: episode234.jpg
+peertube: https://tube.tchncs.de/videos/embed/6b3e1678-975b-4f2d-b128-36ad924dfa46
 tags:
 - IT Tage
 - Zukunft
+thumbnail: episode234.jpg
+title: Folge 244 - IT im Jahr 2034 – Wo wollen wir hin?
+video: 7OaTOhk0vCE
 ---
 
 In einer Welt, in der IT nicht mehr wegzudenken ist, stehen wir vor

--- a/_posts/2024-12-20-episode245.md
+++ b/_posts/2024-12-20-episode245.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 245 - KI in der Software-Entwicklung - Über- oder unterhypt?
-layout: folge
-video: t8H_e-IbSp0
-peertube: https://tube.tchncs.de/videos/embed/d2e3bbaa-443e-4e97-bffc-fb46391b607c
+description: Lisa moderiert ein Gespräch zwischen André Neubauer, Stephan Schmidt,
+  Eberhard und Ralf über KI und die Auswirkungen auf Software-Architekturen.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-e2676f63c107244042cde008ac&v=1734714869
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/download/KI_in_der_Software-Entwicklung_Ueber-_oder_unterhypt.mp3
-description: Lisa moderiert ein Gespräch zwischen André Neubauer, Stephan Schmidt, Eberhard und Ralf über KI und die Auswirkungen auf Software-Architekturen.
-thumbnail: folge245.png
+peertube: https://tube.tchncs.de/videos/embed/d2e3bbaa-443e-4e97-bffc-fb46391b607c
 tags:
 - Künstliche Intelligenz
+thumbnail: folge245.png
+title: Folge 245 - KI in der Software-Entwicklung - Über- oder unterhypt?
+video: t8H_e-IbSp0
 ---
 
 Künstliche Intelligenz (KI) schickt sich an, Software-Entwicklung zu


### PR DESCRIPTION
Add guest and moderator metadata for episodes 245, 244, 243, 242, 241, 240, 239, 238, 237, 236.

Batch 23 - systematically filling remaining gaps in issue #60.
Processed 10 episode files.

Notable guests extracted:
- Episode 243: Bernd Rücker
- Episode 242: Ralf D. Müller
- Episode 239: Cosima Laube und Lisa Schäfer
- Episode 236: Marco Emrich

Changes:
- Added 'guests' field with extracted guest names or empty arrays
- Added 'moderators' field with ["Eberhard Wolff"]
- Systematic gap filling for complete #60 coverage