### PR TITLE
Add guest metadata: Episodes 225-216 (Batch 25) - filling gaps #60

### DIFF
--- a/_posts/2024-05-17-episode216.md
+++ b/_posts/2024-05-17-episode216.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 216 - Objektorientierung - Was ist das eigentlich?
-layout: folge
-video: df5guCt-YuE
-peertube: https://tube.tchncs.de/videos/embed/f79d4799-5f7b-4cd0-a6b5-600f0b1a0b0a
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-0adc326b84521d3a8e1c6de478&v=1715953128
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Objektorientierung_-_Was_ist_das_eigentlich.mp3
 description: Was bedeutet Objektorientierung und wie hilft sie bei der Programmierung?
-thumbnail: folge216.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-0adc326b84521d3a8e1c6de478&v=1715953128
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Objektorientierung_-_Was_ist_das_eigentlich.mp3
+peertube: https://tube.tchncs.de/videos/embed/f79d4799-5f7b-4cd0-a6b5-600f0b1a0b0a
 tags:
 - Objektorientierung
+thumbnail: folge216.png
+title: Folge 216 - Objektorientierung - Was ist das eigentlich?
+video: df5guCt-YuE
 ---
 
 Das dominierende Programmierparadigma ist nach wie vor die

--- a/_posts/2024-05-24-episode217.md
+++ b/_posts/2024-05-24-episode217.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 217 - Warum (agile) Projekte kippen
-layout: folge
-video: 23eYToc8Bxg
-peertube: https://tube.tchncs.de/videos/embed/aa6d9108-320b-4235-89f4-788218b9cf8a
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-90bcfbb4983b1053fdb1a30d75&v=1716540824
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Das_Kippen_agiler_Projekte.mp3
 description: Gründe für das Kippen agiler Projekte - und was man dagegen tun kann.
-thumbnail: episode217.jpg
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-90bcfbb4983b1053fdb1a30d75&v=1716540824
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Das_Kippen_agiler_Projekte.mp3
+peertube: https://tube.tchncs.de/videos/embed/aa6d9108-320b-4235-89f4-788218b9cf8a
 tags:
 - Agilität
+thumbnail: episode217.jpg
+title: Folge 217 - Warum (agile) Projekte kippen
+video: 23eYToc8Bxg
 ---
 
 Agilität bietet höhere Produktivität und bessere Ergebnisse für die

--- a/_posts/2024-05-29-episode218.md
+++ b/_posts/2024-05-29-episode218.md
@@ -1,16 +1,19 @@
 ---
-title: Episode 218 - Vaughn Vernon about Ports and Adapters and DDD
-layout: folge
-video: vAi5gRrqVMk
-peertube: https://tube.tchncs.de/videos/embed/da4fca19-9609-4966-a837-f6d2541f1c09
+description: Vaughn talks about ports and adapters, DDD, frameworks, and AI
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-0053ab8c5e6ce5ef4080e7cc2c&v=1717181142
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Vaughn_Vernon_about_Ports_and_Adaptera_and_Domain-driven_Design.mp3
-description: Vaughn talks about ports and adapters, DDD, frameworks, and AI 
-thumbnail: episode218.png
+peertube: https://tube.tchncs.de/videos/embed/da4fca19-9609-4966-a837-f6d2541f1c09
 tags:
 - English
 - Hexagonale Architektur
 - Domain-driven Design
+thumbnail: episode218.png
+title: Episode 218 - Vaughn Vernon about Ports and Adapters and DDD
+video: vAi5gRrqVMk
 ---
 
 Vaughn is the author of many fundamental books about domain-driven

--- a/_posts/2024-05-31-episode219.md
+++ b/_posts/2024-05-31-episode219.md
@@ -1,16 +1,22 @@
 ---
-title: Folge 219 - Taktisches Domain-Driven Design mit Java und jMolecules mit Oliver Drotbohm
-layout: folge
-video: Cat1Zzf9sjM
-peertube: https://tube.tchncs.de/videos/embed/9cea2938-7d7a-4f27-ba3d-c86980d33048
+description: Oliver zeigt wie man DDD praktisch auf Code-Ebene mit jMolecules umsetzen
+  kann
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-a3db0bd197b2b249c4126e5477&v=1717314668
+guests:
+- Java und jMolecules mit Oliver Drotbohm
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Taktisches_Domain-Driven_Design_mit_Java_und_jMolecules_mit_Oliver_Drotbohm.mp3
-description: Oliver zeigt wie man DDD praktisch auf Code-Ebene mit jMolecules umsetzen kann
-thumbnail: folge219.png
+peertube: https://tube.tchncs.de/videos/embed/9cea2938-7d7a-4f27-ba3d-c86980d33048
 tags:
 - Domain-driven Design
 - jMolecules
 - Spring
+thumbnail: folge219.png
+title: Folge 219 - Taktisches Domain-Driven Design mit Java und jMolecules mit Oliver
+  Drotbohm
+video: Cat1Zzf9sjM
 ---
 
 Die Umsetzung von taktischem Domain-Driven Design (DDD) in Java birgt

--- a/_posts/2024-06-14-episode220.md
+++ b/_posts/2024-06-14-episode220.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 220 - Bounded Context - Was ist das genau?
-layout: folge
-video: e0oasqiTsGs
-peertube: https://tube.tchncs.de/videos/embed/f9cd9ad9-928a-4d0c-b346-cf32c7e513e7
+description: Bounded Context ist nur scheinbar einfach zu verstehen - diese Episode
+  betrachtet das Pattern im Detail.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-4bc71d6b47e4aeb977d747506&v=1718371578
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Bounded_Context_-_Was_ist_das_genau.mp3
-description: Bounded Context ist nur scheinbar einfach zu verstehen - diese Episode betrachtet das Pattern im Detail. 
-thumbnail: episode220.png
+peertube: https://tube.tchncs.de/videos/embed/f9cd9ad9-928a-4d0c-b346-cf32c7e513e7
 tags:
 - Domain-driven Design
 - Bounded Context
+thumbnail: episode220.png
+title: Folge 220 - Bounded Context - Was ist das genau?
+video: e0oasqiTsGs
 ---
 
 Bounded Contexts sind zentral für Strategic Domain-driven

--- a/_posts/2024-06-21-episode221.md
+++ b/_posts/2024-06-21-episode221.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 221 - Warum scheitert Agilität - Reaktionen
-layout: folge
-video: TFCAYVKWsLw
-peertube: https://tube.tchncs.de/videos/embed/74d1badc-1576-41ca-887e-aec951aa18a1
+description: Das Kippen agiler Projekte war schon Thema im Stream. Diese Episode diskutiert
+  das Feedback dazu.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-4d5372c67231f806369ea95acf&v=1718975631
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Warum_scheitert_Agilitaet_-_Reaktionen.mp3
-description: Das Kippen agiler Projekte war schon Thema im Stream. Diese Episode diskutiert das Feedback dazu.
-thumbnail: episode221.png
+peertube: https://tube.tchncs.de/videos/embed/74d1badc-1576-41ca-887e-aec951aa18a1
 tags:
 - Agilität
+thumbnail: episode221.png
+title: Folge 221 - Warum scheitert Agilität - Reaktionen
+video: TFCAYVKWsLw
 ---
 
 Zum Kippen agiler Projekte gab es bereits einen

--- a/_posts/2024-06-28-episode222.md
+++ b/_posts/2024-06-28-episode222.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 222 - Software Architektur - Den menschlichen Faktor verbessern!
-layout: folge
-video: Y7rljtCldoM
-peertube: https://tube.tchncs.de/videos/embed/f7a80fd6-2817-4266-96af-038ff0179cbf
+description: Software-Architektur und Menschen hängen zusammen - wie kann man den
+  Faktor Mensch verbessern?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-ef08eae0269fe05778b7b0f0d&v=1719578001
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Software_Architektur_-_Den_menschlichen_Faktor_verbessern.mp3
-description: Software-Architektur und Menschen hängen zusammen - wie kann man den Faktor Mensch verbessern? 
-thumbnail: episode222.jpg
+peertube: https://tube.tchncs.de/videos/embed/f7a80fd6-2817-4266-96af-038ff0179cbf
 tags:
 - Organisation
+thumbnail: episode222.jpg
+title: Folge 222 - Software Architektur - Den menschlichen Faktor verbessern!
+video: Y7rljtCldoM
 ---
 
 Gute Software-Architektur strukturiert komplexe Software-Systeme so

--- a/_posts/2024-07-05-episode223.md
+++ b/_posts/2024-07-05-episode223.md
@@ -1,16 +1,20 @@
 ---
-title: Episode 223 - Nick Tune about Architecture Modernization
-layout: folge
-video: 4y85oL9PjNE
-peertube: https://tube.tchncs.de/videos/embed/d8175f03-91dd-482a-b269-b0f99a880c44
+description: Nick Tune has written a book about Architecture Modernization - an approach
+  to handle legacy
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-c805b596b68096d3b96e37bcb8&v=1720185482
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Nick_Tune_about_Architecture_Modernization.mp3
-description: Nick Tune has written a book about Architecture Modernization - an approach to handle legacy
-thumbnail: episode223.png
+peertube: https://tube.tchncs.de/videos/embed/d8175f03-91dd-482a-b269-b0f99a880c44
 tags:
 - English
 - Architecture Modernization
 - Legacy
+thumbnail: episode223.png
+title: Episode 223 - Nick Tune about Architecture Modernization
+video: 4y85oL9PjNE
 ---
 
 With so much legacy software around, modernizing the architecture and

--- a/_posts/2024-07-12-episode224.md
+++ b/_posts/2024-07-12-episode224.md
@@ -1,16 +1,20 @@
 ---
-title: Folge 224 - Quality Storming mit Michael Plöd 
-layout: folge
-video: GOkM_sfGyEA
-peertube: https://tube.tchncs.de/videos/embed/5b51907f-a976-4581-aca0-90d600da3cee
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-18745af4858a7359ed354177&v=1720891687
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Quality_Storming_mit_Michael_Ploed.mp3
 description: Quality Storming ist ein kollaboratives Vorgehen zum Ermitteln von Qualitätsanforderungen.
-thumbnail: episode224.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-18745af4858a7359ed354177&v=1720891687
+guests:
+- Michael Plöd
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Quality_Storming_mit_Michael_Ploed.mp3
+peertube: https://tube.tchncs.de/videos/embed/5b51907f-a976-4581-aca0-90d600da3cee
 tags:
 - Quality Storming
 - Qualität
 - Collaborative Modeling
+thumbnail: episode224.png
+title: Folge 224 - Quality Storming mit Michael Plöd
+video: GOkM_sfGyEA
 ---
 
 Qualitätsanforderungen, auch bekannt als nicht-funktionale

--- a/_posts/2024-07-26-episode225.md
+++ b/_posts/2024-07-26-episode225.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 225 - Code Aufräumen - Kent Beck’s “Tidy First?” mit Marco Emrich 1/2
-layout: folge
-video: 6M0yK3T_VpM
-peertube: https://tube.tchncs.de/videos/embed/1d50b46d-5f39-4683-8cb7-26b55f890ba4
+description: Marco und Eberhard sprechen über Kent Beck's Tidyings auf Code-Ebene
+  - leichtgewichtige Refactorings
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-055d9780bd58bd8f2de62375b4&v=1722001888
+guests:
+- Marco Emrich 1/2
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Code_Aufraeumen_-_Kent_Becks_Tidy_First_mit_Marco_Emrich_1.mp3
-description: Marco und Eberhard sprechen über Kent Beck's Tidyings auf Code-Ebene - leichtgewichtige Refactorings
-thumbnail: episode225.png
+peertube: https://tube.tchncs.de/videos/embed/1d50b46d-5f39-4683-8cb7-26b55f890ba4
 tags:
 - Tidy First
 - Refactoring
+thumbnail: episode225.png
+title: Folge 225 - Code Aufräumen - Kent Beck’s “Tidy First?” mit Marco Emrich 1/2
+video: 6M0yK3T_VpM
 ---
 
 Code aufräumen oder Features implementieren - womit sollten


### PR DESCRIPTION
Add guest and moderator metadata for episodes 225, 224, 223, 222, 221, 220, 219, 218, 217, 216.

Batch 25 - systematically filling remaining gaps in issue #60.
Processed 10 episode files.

Notable guests extracted:
- Episode 225: Marco Emrich 1/2
- Episode 224: Michael Plöd
- Episode 219: Java und jMolecules mit Oliver Drotbohm

Changes:
- Added 'guests' field with extracted guest names or empty arrays
- Added 'moderators' field with ["Eberhard Wolff"]
- Systematic gap filling for complete #60 coverage