### PR TITLE
Add guest metadata: Episodes 215-134 (Batch 26) - filling gaps #60

### DIFF
--- a/_posts/2022-09-16-folge134.md
+++ b/_posts/2022-09-16-folge134.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 134 - Domain Prototyping - Iterative Entwicklung mit Domain-driven Design & User Experience mit Tobias Goeschel
-layout: folge
-video: wdggcdnq7T4
-peertube: https://tube.tchncs.de/videos/embed/b6f90058-8c00-4be9-9c8e-d906f74f2616
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-9277a6959f1fdf596968beae1d&v=1663331993
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Domain_Prototyping.mp3
 description: Tobias Goeschel zeigt wie Domain Protoyping UX und DDD vereinigt.
-thumbnail: folge134.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-9277a6959f1fdf596968beae1d&v=1663331993
+guests:
+- Domain-driven Design & User Experience mit Tobias Goeschel
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Domain_Prototyping.mp3
+peertube: https://tube.tchncs.de/videos/embed/b6f90058-8c00-4be9-9c8e-d906f74f2616
 tags:
 - Domain-driven Design
 - UX
+thumbnail: folge134.png
+title: Folge 134 - Domain Prototyping - Iterative Entwicklung mit Domain-driven Design
+  & User Experience mit Tobias Goeschel
+video: wdggcdnq7T4
 ---
 
 Gutes Design von Software-Systemen benötigt - ähnlich wie gutes

--- a/_posts/2022-09-23-folge135.md
+++ b/_posts/2022-09-23-folge135.md
@@ -1,16 +1,20 @@
 ---
-title: Folge 135 - HTTP mit Lucas Dohmen
-layout: folge
-video: uZ4hcgZZNqY
-peertube: https://tube.tchncs.de/videos/embed/dce75161-3416-49e3-b730-bd135b7b8f52
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-47415df9642015835977eea92b&v=1663944517
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/HTTP.mp3
 description: Lucas Dohmen diskutiert das HTTP-Protokoll aus Architektur-Sicht
-thumbnail: folge135.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-47415df9642015835977eea92b&v=1663944517
+guests:
+- Lucas Dohmen
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/HTTP.mp3
+peertube: https://tube.tchncs.de/videos/embed/dce75161-3416-49e3-b730-bd135b7b8f52
 tags:
 - HTTP
 - REST
 - Frontend
+thumbnail: folge135.png
+title: Folge 135 - HTTP mit Lucas Dohmen
+video: uZ4hcgZZNqY
 ---
 
 Seit Anbeginn basiert das Web auf HTTP. Auf den ersten Blick wirkt

--- a/_posts/2022-09-30-folge136.md
+++ b/_posts/2022-09-30-folge136.md
@@ -1,16 +1,21 @@
 ---
-title: Episode 136 - Encouraging Engineering Excellence with Johannes Mainusch and Robert Albrecht
-layout: folge
-peertube: https://tube.tchncs.de/videos/embed/9fa65ac8-9eed-4848-b06d-54de10c5a707
-video: flGyqKRgpVA
+description: Johannes Mainusch, Robert Albrecht, and Eberhard Wolff engineering excellence
+  with a focus on feedback
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-bcdb7c0858cfae8522ae462e67&v=1664609631
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Encouraging_Engineering_Excellence_with_Johannes_Mainusch_and_Robert_Albrecht.mp3
-description: Johannes Mainusch, Robert Albrecht, and Eberhard Wolff engineering excellence with a focus on feedback 
-thumbnail: folge136.png
+peertube: https://tube.tchncs.de/videos/embed/9fa65ac8-9eed-4848-b06d-54de10c5a707
 tags:
 - English
 - Karriere
 - Engineering Excellence
+thumbnail: folge136.png
+title: Episode 136 - Encouraging Engineering Excellence with Johannes Mainusch and
+  Robert Albrecht
+video: flGyqKRgpVA
 ---
 
 Are you already a 10-star expert in Vue.js or Flutter or TypeScript,

--- a/_posts/2022-10-07-folge137.md
+++ b/_posts/2022-10-07-folge137.md
@@ -1,17 +1,21 @@
 ---
-title: Episode 137 - Non-linear Thinking with Diana Montalion
-layout: folge
-video: pOvbpuv5W1A
-peertube: https://tube.tchncs.de/videos/embed/5fceeafb-7430-4623-a584-115bdc10ee32
+description: Diana Montalion talks about non-liner thinking and its application to
+  software architecture.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-4e6a924bf0a7cde75c32f5285a&v=1665155207
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Non-linear_Thinking_with_Diana_Montalion.mp3
-description: Diana Montalion talks about non-liner thinking and its application to software architecture.
-thumbnail: folge137.png
+peertube: https://tube.tchncs.de/videos/embed/5fceeafb-7430-4623-a584-115bdc10ee32
 tags:
 - English
 - Nonlinear Thinking
 - Soziotechnische Systeme
 - Systems Thinking
+thumbnail: folge137.png
+title: Episode 137 - Non-linear Thinking with Diana Montalion
+video: pOvbpuv5W1A
 ---
 
 We are used to linear thinking - but really nonlinear thinking and

--- a/_posts/2022-10-14-folge138.md
+++ b/_posts/2022-10-14-folge138.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 138 - Was ist Documentation as Code? mit Falk Sippach
-layout: folge
-video: 7cIQfjDYK04
-peertube: https://tube.tchncs.de/videos/embed/a1b7bb8e-c56b-43c3-8c4e-a91ce4f160ad
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-e011dd5d00cbf17df4549170f1&v=1665754799
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Was_ist_Documentation_as_Code_mit_Falk_Sippach.mp3
 description: Falk Sippach spricht mit Lisa Schäfer über Documentation as Code
-thumbnail: folge138.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-e011dd5d00cbf17df4549170f1&v=1665754799
+guests:
+- Falk Sippach
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Was_ist_Documentation_as_Code_mit_Falk_Sippach.mp3
+peertube: https://tube.tchncs.de/videos/embed/a1b7bb8e-c56b-43c3-8c4e-a91ce4f160ad
 tags:
 - Dokumentation
+thumbnail: folge138.png
+title: Folge 138 - Was ist Documentation as Code? mit Falk Sippach
+video: 7cIQfjDYK04
 ---
   
 Falk Sippach wird beim Software Architecture Gathering den Vortrag

--- a/_posts/2022-10-21-folge139.md
+++ b/_posts/2022-10-21-folge139.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 139 - Christoph Iserlohn & Lisa Schäfer - Architektur und Security 
-layout: folge
-video: SA9TEltoedc
-peertube: https://tube.tchncs.de/videos/embed/ba0d46b4-88f4-43a3-999d-6119e269ae94
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-bebc2dc76cfff6451bc484f01a&v=1666367885
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Christoph_Iserlohn_und_Lisa_Moritz_Architektur_und_Security.mp3
 description: Christoph Iserlohn spricht mit Lisa Schäfer über Sicherheit aus Architektur-Sicht
-thumbnail: folge139.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-bebc2dc76cfff6451bc484f01a&v=1666367885
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Christoph_Iserlohn_und_Lisa_Moritz_Architektur_und_Security.mp3
+peertube: https://tube.tchncs.de/videos/embed/ba0d46b4-88f4-43a3-999d-6119e269ae94
 tags:
 - Sicherheit
+thumbnail: folge139.png
+title: Folge 139 - Christoph Iserlohn & Lisa Schäfer - Architektur und Security
+video: SA9TEltoedc
 ---
 
 

--- a/_posts/2022-10-28-folge140.md
+++ b/_posts/2022-10-28-folge140.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 140 - Zukunftssichere Architekturen - Keine gute Idee?
-layout: folge
-video: x1s0_QwGOMQ
-peertube: https://tube.tchncs.de/videos/embed/018ac786-4fde-473c-ae0e-f56952cdf72b
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-f827cc21a5c9e299ac5b41ec1e&v=1666965074
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Zukunftssichere_Architekturen_Keine_gute_Idee.mp3
 description: Warum sollte man eine Architektur nicht zukunftssicher anlegen?
-thumbnail: folge140.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-f827cc21a5c9e299ac5b41ec1e&v=1666965074
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Zukunftssichere_Architekturen_Keine_gute_Idee.mp3
+peertube: https://tube.tchncs.de/videos/embed/018ac786-4fde-473c-ae0e-f56952cdf72b
 tags:
 - Langlebigkeit
+thumbnail: folge140.png
+title: Folge 140 - Zukunftssichere Architekturen - Keine gute Idee?
+video: x1s0_QwGOMQ
 ---
 
 Architektur steht für das stabile, schwer zu ändernde. Also sollte

--- a/_posts/2022-11-04-folge141.md
+++ b/_posts/2022-11-04-folge141.md
@@ -1,16 +1,20 @@
 ---
-title: Folge 141 - Auftragstaktik - Agilität beim Militär? mit Sönke Marahrens
-layout: folge
-video: Oc4X7AZpJgA
-peertube: https://tube.tchncs.de/videos/embed/6b9fd03a-783c-42c9-bac1-a813c41470e7
+description: null
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-d955cb1f0ad4e4cba222056487&v=1667569089
+guests:
+- Sönke Marahrens
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Auftragstaktik_-_Agilitaet_beim_Militaer_mit_Soenke_Marahrens.mp3
-description: 
-thumbnail: folge141.png
+peertube: https://tube.tchncs.de/videos/embed/6b9fd03a-783c-42c9-bac1-a813c41470e7
 tags:
 - Auftragstaktik
 - Agilität
 - Organisation
+thumbnail: folge141.png
+title: Folge 141 - Auftragstaktik - Agilität beim Militär? mit Sönke Marahrens
+video: Oc4X7AZpJgA
 ---
 
 Auftragstaktik ist ein Konzept im Militär: Man gibt nur Ziele vor. Wie

--- a/_posts/2023-10-13-episode184.md
+++ b/_posts/2023-10-13-episode184.md
@@ -1,17 +1,21 @@
 ---
-title: Folge 184 - Bert Jan Schrijver about Generic or Specific?
-layout: folge
-video: eJlRttUDrog
-peertube: https://tube.tchncs.de/videos/embed/94fabfc9-3191-4e89-83f9-9968505e9d8d
+description: Bert Jan Schrijver discusses whether we should build generic or specific
+  solutions.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-dada9cc33e65f90c992dae675&v=1697221121
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Bert_Jan_Schrijver_Generic_or_Specific.mp3
-description: Bert Jan Schrijver discusses whether we should build generic or specific solutions.
-thumbnail: episode184.png
+peertube: https://tube.tchncs.de/videos/embed/94fabfc9-3191-4e89-83f9-9968505e9d8d
 tags:
 - English
 - Grundlagen
 - Live from Software Architecture Gathering
 - Wiederverwendung
+thumbnail: episode184.png
+title: Folge 184 - Bert Jan Schrijver about Generic or Specific?
+video: eJlRttUDrog
 ---
 
 Usually, this is not an easy question to answer. The answer depends on

--- a/_posts/2024-05-10-episode215.md
+++ b/_posts/2024-05-10-episode215.md
@@ -1,15 +1,19 @@
 ---
-title: Episode 215 - Alberto Brandolini - The Chasm Between Architecture and Business
-layout: folge
-video: n89L3I8P7uQ
-peertube: https://tube.tchncs.de/videos/embed/ca109b5b-221e-4458-9c97-0f3d7d10828a
+description: Alberto Brandolini discusses why architecture and business need to collaborate
+  so closely - and why
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-6205690fbc6033ebc0ce6715bb&v=1715345615
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Alberto_Brandolini_The_Chasm_Between_Architecture_and_Business.mp3
-description: Alberto Brandolini discusses why architecture and business need to collaborate so closely - and why
-thumbnail: episode215.png
+peertube: https://tube.tchncs.de/videos/embed/ca109b5b-221e-4458-9c97-0f3d7d10828a
 tags:
 - Domain-driven Design
 - English
+thumbnail: episode215.png
+title: Episode 215 - Alberto Brandolini - The Chasm Between Architecture and Business
+video: n89L3I8P7uQ
 ---
 
 Alberto Brandolini is the creator of Event Storming, a technique aimed


### PR DESCRIPTION
Add guest and moderator metadata for episodes 215, 184, 141, 140, 139, 138, 137, 136, 135, 134.

Batch 26 - systematically filling remaining gaps in issue #60.
Processed 10 episode files.

Notable guests extracted:
- Episode 141: Sönke Marahrens
- Episode 138: Falk Sippach
- Episode 135: Lucas Dohmen
- Episode 134: Domain-driven Design & User Experience mit Tobias Goeschel

Changes:
- Added 'guests' field with extracted guest names or empty arrays
- Added 'moderators' field with ["Eberhard Wolff"]
- Systematic gap filling for complete #60 coverage