### PR TITLE
Add guest metadata: Episodes 113-104 (Batch 29) - filling gaps #60

### DIFF
--- a/_posts/2022-02-01-folge104.md
+++ b/_posts/2022-02-01-folge104.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 104 - Erik Dörnenburg - DevSecOps - live von der OOP
-layout: folge
-video: C2fJ5TqMxIM
-peertube: https://tube.tchncs.de/videos/embed/4e23a60e-251d-4736-a419-5ac6549a8dbd
+description: Wir kennen alle DevOps - aber was ist DevSecOps und warum gehört ausgerechnet
+  Sicherheit dazu?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-d12567406c025b77faf4170631&v=1643733147
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Erik_Doernenburg_DevSecOps.mp3
-description: Wir kennen alle DevOps - aber was ist DevSecOps und warum gehört ausgerechnet Sicherheit dazu?
-thumbnail: OOP2022.png
+peertube: https://tube.tchncs.de/videos/embed/4e23a60e-251d-4736-a419-5ac6549a8dbd
 tags:
 - DevSecOps
 - Live von der OOP
+thumbnail: OOP2022.png
+title: Folge 104 - Erik Dörnenburg - DevSecOps - live von der OOP
+video: C2fJ5TqMxIM
 ---
 
 Wir kennen alle DevOps - aber was ist DevSecOps und warum gehört

--- a/_posts/2022-02-01-folge105.md
+++ b/_posts/2022-02-01-folge105.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 105 - Lucas Dohmen, Lars Hupel - Hilfe, wir syncen! - live von der OOP
-layout: folge
-video: glCrvR2MYxM
-peertube: https://tube.tchncs.de/videos/embed/fed467ba-3cb4-44cd-9b6b-0e2780c02ece
+description: Daten beispielsweise lokal zu kopieren, um offline zu arbeiten, ist eine
+  Herausforderung. Wir diskutieren, wie man sie meistern kann.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-9cda909ea7c72d2b2f7101204d&v=1643734572
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Lucas_Dohmen_Lars_Hupel_Hilfe_wir_syncen.mp3
-description: Daten beispielsweise lokal zu kopieren, um offline zu arbeiten, ist eine Herausforderung. Wir diskutieren, wie man sie meistern kann.
-thumbnail: OOP2022.png
+peertube: https://tube.tchncs.de/videos/embed/fed467ba-3cb4-44cd-9b6b-0e2780c02ece
 tags:
 - Live von der OOP
 - CRDT
+thumbnail: OOP2022.png
+title: Folge 105 - Lucas Dohmen, Lars Hupel - Hilfe, wir syncen! - live von der OOP
+video: glCrvR2MYxM
 ---
 
 Daten beispielsweise lokal zu kopieren, um offline zu arbeiten, ist

--- a/_posts/2022-02-01-folge106.md
+++ b/_posts/2022-02-01-folge106.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 106 - Anne Herwanger, Alexandra Hoitz, Stefan Link - Resiliente Organisation und resiliente Software Architektur - live von der OOP
-layout: folge
-video: BTURNT7EQhk
-peertube: https://tube.tchncs.de/videos/embed/8c7dbdb6-6a0f-40e1-8f0c-31e2cf7eeeb5
+description: Die Organisation hat großen Einfluss auf die Architektur. Wie kann man
+  sich diesen Zusammenhang zu Nutze machen?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-0e775e30d8bdd18eca5f8ac9ab&v=1643736061
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Resiliente_Organisation_und_resiliente_Software-Architektur.mp3
-description: Die Organisation hat großen Einfluss auf die Architektur. Wie kann man sich diesen Zusammenhang zu Nutze machen?
-thumbnail: OOP2022.png
+peertube: https://tube.tchncs.de/videos/embed/8c7dbdb6-6a0f-40e1-8f0c-31e2cf7eeeb5
 tags:
 - Live von der OOP
 - Organisation
+thumbnail: OOP2022.png
+title: Folge 106 - Anne Herwanger, Alexandra Hoitz, Stefan Link - Resiliente Organisation
+  und resiliente Software Architektur - live von der OOP
+video: BTURNT7EQhk
 ---
 
 Resiliente Organisation und resiliente Software-Architektur: Die

--- a/_posts/2022-02-02-folge107.md
+++ b/_posts/2022-02-02-folge107.md
@@ -1,16 +1,21 @@
 ---
-title: Folge 107 - Klima-Panel mit Marina Köhn, Jutta Eckstein, Max Schulze - live von der OOP!
-layout: folge
-video: SQ3sbRXK8iM
-peertube: https://tube.tchncs.de/videos/embed/88c41b7a-a560-468a-a424-7e0aaa1de151
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-1f7707f1c8a1124db68644df97&v=1643821883
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/KlimaPanel.mp3
 description: Wie kann Software-Architektur im Kampf gegen die Klima-Katastrophe helfen?
-thumbnail: OOP2022-klima.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-1f7707f1c8a1124db68644df97&v=1643821883
+guests:
+- Marina Köhn, Jutta Eckstein, Max Schulze - live von der OOP!
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/KlimaPanel.mp3
+peertube: https://tube.tchncs.de/videos/embed/88c41b7a-a560-468a-a424-7e0aaa1de151
 tags:
 - Live von der OOP
 - Klimakatastrophe
 - Ethik
+thumbnail: OOP2022-klima.png
+title: Folge 107 - Klima-Panel mit Marina Köhn, Jutta Eckstein, Max Schulze - live
+  von der OOP!
+video: SQ3sbRXK8iM
 ---
 
 Die Klima-Katastrophe ist eine der wichtigsten

--- a/_posts/2022-02-03-folge108.md
+++ b/_posts/2022-02-03-folge108.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 108 -  Katrin Rabow, Nicola Marsden, Silke Foth - Diversity-Panel - live von der OOP
-layout: folge
-video: wBjUkCGFwhU
+description: Wie kann Diversityhttps://1evriw.podcaster.de/software-architektur-im-stream/media/DiversityPanel.mp3
+  in der Software-Entwicklung erhöht werden?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-71cde552657d6f1a1b5ef484ff&v=1643896175
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/DiversityPanel.mp3
 peertube: https://tube.tchncs.de/videos/embed/ef06e5d8-76e5-4329-8c5a-2c5fdea7ab57
-description: Wie kann Diversityhttps://1evriw.podcaster.de/software-architektur-im-stream/media/DiversityPanel.mp3 in der Software-Entwicklung erhöht werden?
-thumbnail: OOP2022-diversity.png
 tags:
 - Diversity
 - Live von der OOP
+thumbnail: OOP2022-diversity.png
+title: Folge 108 -  Katrin Rabow, Nicola Marsden, Silke Foth - Diversity-Panel - live
+  von der OOP
+video: wBjUkCGFwhU
 ---
 
 In der Software-Entwicklung sind zahlreiche Gruppen

--- a/_posts/2022-02-11-folge109.md
+++ b/_posts/2022-02-11-folge109.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 109 - Was ist Software-Architektur überhaupt?
+description: Wir diskutieren, was Software-Architektur ist anhand von Definitionen
+  und Tweets.
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-4948e59294e64abd72ae820f93&v=1644669795
+guests: []
 layout: folge
-video: lFOjTKDdp8c
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/WasIstSoftwareArchitekturUeberhaupt.mp3
 peertube: https://tube.tchncs.de/videos/embed/8d2129fc-32eb-4e72-bdd5-dfb2002f5881
 sketchnote-video: e-W9_G2UWHo
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-4948e59294e64abd72ae820f93&v=1644669795
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/WasIstSoftwareArchitekturUeberhaupt.mp3
-description: Wir diskutieren, was Software-Architektur ist anhand von Definitionen und Tweets.
-thumbnail: folge109.png
 tags:
 - Grundlagen
+thumbnail: folge109.png
+title: Folge 109 - Was ist Software-Architektur überhaupt?
+video: lFOjTKDdp8c
 ---
 
 Software-Architektur im Stream hat jetzt über 100 Folgen - aber eine

--- a/_posts/2022-02-18-folge110.md
+++ b/_posts/2022-02-18-folge110.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 110 - Conway's Law
-layout: folge
-video: 7qJp_CXAezU
-peertube: https://tube.tchncs.de/videos/embed/88f00b66-8eb2-4fc8-a663-9380d18e1032
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-e6c7ecb6ebb48aec4b867ac374&v=1645360670
-mp3: https://1evriw.podcaster.de/download/ConwaysLaw.mp3?origin=embed
 description: Was besagt das Gesetz von Conway / Conway's Law genau?
-thumbnail: folge110.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-e6c7ecb6ebb48aec4b867ac374&v=1645360670
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/download/ConwaysLaw.mp3?origin=embed
+peertube: https://tube.tchncs.de/videos/embed/88f00b66-8eb2-4fc8-a663-9380d18e1032
 tags:
 - Organisation
+thumbnail: folge110.png
+title: Folge 110 - Conway's Law
+video: 7qJp_CXAezU
 ---
 
 Das Gesetz von Conway stellt einen Zusammenhang zwischen der

--- a/_posts/2022-02-25-folge111.md
+++ b/_posts/2022-02-25-folge111.md
@@ -1,16 +1,19 @@
 ---
-title: Folge 111 - Wir bauen eine Sofware-Architektur
-layout: folge
-video: -FCkp1aJzRY
-peertube: https://tube.tchncs.de/videos/embed/612aeccd-0e38-4457-b9c8-3db1d1c2563c
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-26a6b7bb3be852427d48eba367&v=1646073315
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/WirBauenEineSoftwareArchitektur-xcf.mp3
 description: In dieser Episode erstellen wir eine Software-Architektur - live!
-thumbnail: folge111.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-26a6b7bb3be852427d48eba367&v=1646073315
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/WirBauenEineSoftwareArchitektur-xcf.mp3
+peertube: https://tube.tchncs.de/videos/embed/612aeccd-0e38-4457-b9c8-3db1d1c2563c
 tags:
 - Grundlagen
 - Qualität
 - Wir bauen eine Software-Architektur
+thumbnail: folge111.png
+title: Folge 111 - Wir bauen eine Sofware-Architektur
+video: -FCkp1aJzRY
 ---
 
 In dieser Episode erstellen wir eine Software-Architektur live. So

--- a/_posts/2022-03-11-folge112.md
+++ b/_posts/2022-03-11-folge112.md
@@ -1,16 +1,19 @@
 ---
-title: Folge 112 - Wir bauen eine Software-Architektur - Struktur der Lösung
+description: Wir bauen die Struktur der beispielhaften Software-Architektur.
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-d063844c519b9221e10c3e868e&v=1647196300
+guests: []
 layout: folge
-video: K512HtCbb2Q
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/WirBauenEineSoftwareArchitekturStrukturDerLoesung.mp3
 peertube: https://tube.tchncs.de/videos/embed/22fe5130-ce78-4e9d-9f26-960661a069f6
 sketchnote-video: SR7rEQ7nSzg
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-d063844c519b9221e10c3e868e&v=1647196300
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/WirBauenEineSoftwareArchitekturStrukturDerLoesung.mp3
-description: Wir bauen die Struktur der beispielhaften Software-Architektur.
-thumbnail: folge111.png
 tags:
 - Grundlagen
 - Wir bauen eine Software-Architektur
+thumbnail: folge111.png
+title: Folge 112 - Wir bauen eine Software-Architektur - Struktur der Lösung
+video: K512HtCbb2Q
 ---
 
 Nachdem wir in der [vorherigen Episode](/2022/02/25/folge111.html)

--- a/_posts/2022-03-25-folge113.md
+++ b/_posts/2022-03-25-folge113.md
@@ -1,17 +1,20 @@
 ---
-title: Folge 113 - Qualitäten / nicht-funktionale Anforderungen umsetzen - Wir bauen eine Software-Architektur
+description: Wir suchen Lösungen für die Qualitätsszenarien.
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-dd2e7c984071a881b9e9e996ad&v=1648216524
+guests: []
 layout: folge
-video: oteC-_RZzPk
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Qualitaeten_nicht-funktionale_Anforderungen_umsetzen_-_Wir_bauen_eine_Software-Architektur.mp3
 peertube: https://tube.tchncs.de/videos/embed/9a804c23-007d-4119-9781-ead43ed0d436
 sketchnote-video: VCLfh1mWP00
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-dd2e7c984071a881b9e9e996ad&v=1648216524
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Qualitaeten_nicht-funktionale_Anforderungen_umsetzen_-_Wir_bauen_eine_Software-Architektur.mp3
-description: Wir suchen Lösungen für die Qualitätsszenarien.
-thumbnail: folge111.png
 tags:
 - Grundlagen
 - Wir bauen eine Software-Architektur
-
+thumbnail: folge111.png
+title: Folge 113 - Qualitäten / nicht-funktionale Anforderungen umsetzen - Wir bauen
+  eine Software-Architektur
+video: oteC-_RZzPk
 ---
 
 In den [letzten](/2022/02/25/folge111.html)


### PR DESCRIPTION
Add guest and moderator metadata for episodes 113, 112, 111, 110, 109, 108, 107, 106, 105, 104.

Batch 29 - systematically filling remaining gaps in issue #60.
Processed 10 episode files.

Notable guests extracted:
- Episode 107: Marina Köhn, Jutta Eckstein, Max Schulze - live von der OOP!

Changes:
- Added 'guests' field with extracted guest names or empty arrays
- Added 'moderators' field with ["Eberhard Wolff"]
- Systematic gap filling for complete #60 coverage