### PR TITLE
Add guest metadata: Episodes 103-74 (Batch 30) - filling gaps #60

### DIFF
--- a/_posts/2021-09-10-folge74.md
+++ b/_posts/2021-09-10-folge74.md
@@ -1,11 +1,14 @@
 ---
-title: Folge 74 - Bücher Schreiben - Warum und Wie?
-layout: folge
-video: JbTgr9suyGE
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-7c9b21d9d95cbb014400e4826b&v=1631541626
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/BuecherSchreiben.mp3
 description: Wie schreibt man ein Buch - und warum überhaupt?
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-7c9b21d9d95cbb014400e4826b&v=1631541626
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/BuecherSchreiben.mp3
 thumbnail: folge74.png
+title: Folge 74 - Bücher Schreiben - Warum und Wie?
+video: JbTgr9suyGE
 ---
 
 Wissensaustausch ist gerade bei Software-Architektur entscheidend. Und

--- a/_posts/2021-09-17-folge75.md
+++ b/_posts/2021-09-17-folge75.md
@@ -1,17 +1,23 @@
 ---
-title: Folge 75 - Architekturstil-Vergleich und Architektur-Hamburger mit Henning Schwentner
-layout: folge
-video: RJ0k6_MgsN4
-sketchnote-video: Cyp6rOn1-iA
+description: Welche Architekturstile gibt es - und warum ist der Architektur-Hamburger
+  wichtig?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-5bd3b08c27be9d41be70ae5eb9&v=1632222595
+guests:
+- Henning Schwentner
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/ArchitekturStilVergleichUndArchitekturHamburgerHenningSchwentner.mp3
-description: Welche Architekturstile gibt es - und warum ist der Architektur-Hamburger wichtig?
-thumbnail: folge75.png
+sketchnote-video: Cyp6rOn1-iA
 tags:
 - Architekturstile
 - Architektur-Hamburger
 - Grundlagen
 - Hexagonale Architektur
+thumbnail: folge75.png
+title: Folge 75 - Architekturstil-Vergleich und Architektur-Hamburger mit Henning
+  Schwentner
+video: RJ0k6_MgsN4
 ---
 
 In der Software-Architektur gibt es viele verschiedene Stile:

--- a/_posts/2021-09-24-folge76.md
+++ b/_posts/2021-09-24-folge76.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 76 - Lose Kopplung
-layout: folge
-video: B_gUlkBBpJI
-sketchnote-video: KHXTMiLI7T4
+description: Lose Kopplung führt zu besserer Änderbarkeit - aber was ist das genau
+  und wie erreicht man es?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-e6180f8adfa8310dd2401753ac&v=1632515617
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/LoseKopplung.mp3
-description: Lose Kopplung führt zu besserer Änderbarkeit - aber was ist das genau und wie erreicht man es?
-thumbnail: folge76.png
+sketchnote-video: KHXTMiLI7T4
 tags:
 - Grundlagen
 - Modularisierung
+thumbnail: folge76.png
+title: Folge 76 - Lose Kopplung
+video: B_gUlkBBpJI
 ---
 
 Lose Kopplung stellt eine grundlegende Eigenschaft eines modularen

--- a/_posts/2022-01-07-episode97.md
+++ b/_posts/2022-01-07-episode97.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 97 - Junior oder Senior - Was ist der Unterschied?
+description: Was unterscheidet Juniors von Seniors? Diskussions anhand der Reaktionen
+  auf einen Tweets
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-43f18da7ce754bf99e4cba20c8&v=1641731621
+guests: []
 layout: folge
-video: YnfWJg-0Zr4
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/JuniorSeniorWasIstDerUnterschied.mp3
 peertube: https://tube.tchncs.de/videos/embed/944ba7d0-5e5f-4ef4-8ba8-dd55245789fb
 sketchnote-video: sL6LD6uQrAs
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-43f18da7ce754bf99e4cba20c8&v=1641731621
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/JuniorSeniorWasIstDerUnterschied.mp3
-description: Was unterscheidet Juniors von Seniors? Diskussions anhand der Reaktionen auf einen Tweets
-thumbnail: episode97.png
 tags:
 - Karriere
+thumbnail: episode97.png
+title: Folge 97 - Junior oder Senior - Was ist der Unterschied?
+video: YnfWJg-0Zr4
 ---
 
 In der Software-Entwickler gibt es Juniors und Seniors - aber was ist

--- a/_posts/2022-01-14-episode98.md
+++ b/_posts/2022-01-14-episode98.md
@@ -1,16 +1,20 @@
 ---
-title: Folge 98 - Asynchrone Kommunikation mit HTTP Feeds - Jochen Christ
+description: HTTP Feeds sind eine leichtgewichtige Alternative für asynchrone Kommunikation.
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-a72f7feac1cdfaa266d6e5f16b&v=1642177096
+guests:
+- HTTP Feeds - Jochen Christ
 layout: folge
-video: b1uwA1j7kLs
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/HTTP-Feeds.mp3
 peertube: https://tube.tchncs.de/videos/embed/522099dc-9329-4874-ac8b-db31b9317289
 sketchnote-video: viuB-dT1S3g
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-a72f7feac1cdfaa266d6e5f16b&v=1642177096
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/HTTP-Feeds.mp3
-description: HTTP Feeds sind eine leichtgewichtige Alternative für asynchrone Kommunikation. 
-thumbnail: folge98.png
 tags:
 - HTTP Feeds
 - HTTP
+thumbnail: folge98.png
+title: Folge 98 - Asynchrone Kommunikation mit HTTP Feeds - Jochen Christ
+video: b1uwA1j7kLs
 ---
 
 Asynchrone Kommunikation hat gerade bei Self-contained Systems oder

--- a/_posts/2022-01-19-episode99.md
+++ b/_posts/2022-01-19-episode99.md
@@ -1,16 +1,20 @@
 ---
-title: Folge 99 - Sam Newman - Monolith to Microservices
-layout: folge
-video: PZlVTrJDnhw
-peertube: https://tube.tchncs.de/videos/embed/adaf7745-8161-4333-a30b-ebd20ede527a
-description: Sam Newman discusses microservices and how to migrate from a monolith to microservices.
-thumbnail: episode99.png
+description: Sam Newman discusses microservices and how to migrate from a monolith
+  to microservices.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-7db7bed6aa7b9ace017de642ac&v=1642703220
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/SamNewmanMonolithToMicroservices.mp3
+peertube: https://tube.tchncs.de/videos/embed/adaf7745-8161-4333-a30b-ebd20ede527a
 tags:
 - English
 - Microservices
 - Migration
+thumbnail: episode99.png
+title: Folge 99 - Sam Newman - Monolith to Microservices
+video: PZlVTrJDnhw
 ---
 
 Many teams work on monolithic applications but want to migrate to a

--- a/_posts/2022-01-27-episode100.md
+++ b/_posts/2022-01-27-episode100.md
@@ -1,16 +1,20 @@
 ---
-title: Episode 100 - Daniel Terhorst-North - SOLID vs. CUPID
-layout: folge
-video: 2QahGarHpXQ
-peertube: https://tube.tchncs.de/videos/embed/c9ea5337-a2d3-410c-b55b-dcbc86595184
+description: Daniel Terhorst-North talks about the problems of the SOLID principles
+  and the alternative CUPID
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-f6ca793e985995716c96f97469&v=1643316833
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Daniel_Terhorst-North_-_SOLID_vs-_CUPID.mp3
-description: Daniel Terhorst-North talks about the problems of the SOLID principles and the alternative CUPID
-thumbnail: episode100.png
+peertube: https://tube.tchncs.de/videos/embed/c9ea5337-a2d3-410c-b55b-dcbc86595184
 tags:
 - English
 - SOLID
 - CUPID
+thumbnail: episode100.png
+title: Episode 100 - Daniel Terhorst-North - SOLID vs. CUPID
+video: 2QahGarHpXQ
 ---
 
 The SOLID principles are well-established as the foundation of

--- a/_posts/2022-01-31-episode101.md
+++ b/_posts/2022-01-31-episode101.md
@@ -1,16 +1,20 @@
 ---
-title: Episode 101 - Kenny Baas-Schwegler, Gien Verschatse, Evelyn Van Kelle - Facilitating Collaborative Design Decisions - Live from OOP
-layout: folge
-video: p3sSX529Zec
-peertube: https://tube.tchncs.de/videos/embed/e39b6106-62fa-4624-8f6b-591fe594d5a5
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-136d34c42c0b505e3ea3dd7701&v=1643710532
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Facilitating_Collaborative_Design_Decisions.mp3
 description: Software is developed in teams so design decision must be done collaboratively.
-thumbnail: OOP2022.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-136d34c42c0b505e3ea3dd7701&v=1643710532
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Facilitating_Collaborative_Design_Decisions.mp3
+peertube: https://tube.tchncs.de/videos/embed/e39b6106-62fa-4624-8f6b-591fe594d5a5
 tags:
 - English
 - Organisation
 - Live von der OOP
+thumbnail: OOP2022.png
+title: Episode 101 - Kenny Baas-Schwegler, Gien Verschatse, Evelyn Van Kelle - Facilitating
+  Collaborative Design Decisions - Live from OOP
+video: p3sSX529Zec
 ---
 
 Software is developed in teams so design decision must be done

--- a/_posts/2022-01-31-episode102.md
+++ b/_posts/2022-01-31-episode102.md
@@ -1,17 +1,20 @@
 ---
-title: Episode 102 - Rik Marselis - Testing and Quality - Live from OOP
-layout: folge
-video: 6PO7u4Hdb1w
-peertube: https://tube.tchncs.de/videos/embed/8ecd4661-5228-475b-bc89-c73865941ab9
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-1a86ea304b6a6f97c86c2c78f4&v=1643721591
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Rik_Marselis_Testing_and_Quality.mp3
 description: Testing alone is not enough - the alternative is quality engineering.
-thumbnail: OOP2022.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-1a86ea304b6a6f97c86c2c78f4&v=1643721591
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Rik_Marselis_Testing_and_Quality.mp3
+peertube: https://tube.tchncs.de/videos/embed/8ecd4661-5228-475b-bc89-c73865941ab9
 tags:
 - English
 - Qualität
 - Test
 - Live von der OOP
+thumbnail: OOP2022.png
+title: Episode 102 - Rik Marselis - Testing and Quality - Live from OOP
+video: 6PO7u4Hdb1w
 ---
 
 Testing alone is not enough - the alternative is quality engineering.

--- a/_posts/2022-01-31-episode103.md
+++ b/_posts/2022-01-31-episode103.md
@@ -1,16 +1,20 @@
 ---
-title: Episode 103 - Scott Ambler - Data Technical Debt - Live from OOP
-layout: folge
-video: 9rynLTSAuxk
-peertube: https://tube.tchncs.de/videos/embed/5ae470ee-533a-477b-9358-f424037d0db4
+description: Technical debt is a well-known concept - but data can also cause technical
+  debt.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-30c5a5f8fa481915fb5adeff1&v=1643727611
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Scott_Ambler_Data_Technical_Debt.mp3
-description: Technical debt is a well-known concept - but data can also cause technical debt.
-thumbnail: OOP2022.png
+peertube: https://tube.tchncs.de/videos/embed/5ae470ee-533a-477b-9358-f424037d0db4
 tags:
 - English
 - Live von der OOP
 - Technical Debt
+thumbnail: OOP2022.png
+title: Episode 103 - Scott Ambler - Data Technical Debt - Live from OOP
+video: 9rynLTSAuxk
 ---
 
 Technical debt is a well-known concept - but data can also cause technical debt.


### PR DESCRIPTION
Add guest and moderator metadata for episodes 103, 102, 101, 100, 99, 98, 97, 76, 75, 74.

Batch 30 - systematically filling remaining gaps in issue #60.
Processed 10 episode files.

Notable guests extracted:
- Episode 98: HTTP Feeds - Jochen Christ
- Episode 75: Henning Schwentner

Changes:
- Added 'guests' field with extracted guest names or empty arrays
- Added 'moderators' field with ["Eberhard Wolff"]
- Systematic gap filling for complete #60 coverage