### PR TITLE
Add guest metadata: Episodes 73-64 (Batch 31) - filling gaps #60

### DIFF
--- a/_posts/2021-06-25-folge64.md
+++ b/_posts/2021-06-25-folge64.md
@@ -1,12 +1,16 @@
 ---
-title: Folge 64 - Christoph Iserlohn zu Security und Software-Architektur
-layout: folge
-video: xcjQHZu-Ic4
+description: Christoph Iserlohn zeigt auf, warum Security auch für die Software-Architektur
+  sehr wichtig ist.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-bb17b340f67f847c5235ba8c3f&v=1624642009
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/ChristophIserlohnSecurity.mp3
-description: Christoph Iserlohn zeigt auf, warum Security auch für die Software-Architektur sehr wichtig ist.
-thumbnail: folge64.png
 tags: Sicherheit
+thumbnail: folge64.png
+title: Folge 64 - Christoph Iserlohn zu Security und Software-Architektur
+video: xcjQHZu-Ic4
 ---
 
 Lisa Maria Schäfer spricht mit Christoph Iserlohn im Stream

--- a/_posts/2021-07-02-folge65.md
+++ b/_posts/2021-07-02-folge65.md
@@ -1,15 +1,18 @@
 ---
-title: Folge 65 -  Muss ich mich schämen, ein Software-Architekt zu sein?
-layout: folge
-video: R9OZmH9UU-4
-sketchnote-video: s73WQsayTuY
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-37b0fe79a2025f5f9ff9b9dac&v=1625238308
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Schaemen.mp3
 description: Weitere Erklärung zum heise Blog Post
-thumbnail: OOP.jpg
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-37b0fe79a2025f5f9ff9b9dac&v=1625238308
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Schaemen.mp3
+sketchnote-video: s73WQsayTuY
 tags:
 - Sicherheit
 - Ethik
+thumbnail: OOP.jpg
+title: Folge 65 -  Muss ich mich schämen, ein Software-Architekt zu sein?
+video: R9OZmH9UU-4
 ---
 
 Ich habe in meinem heise-Blog einen

--- a/_posts/2021-07-09-folge66.md
+++ b/_posts/2021-07-09-folge66.md
@@ -1,12 +1,17 @@
 ---
-title: Folge 66 - Prof. Christiane Floyd zu “menschenzentrierter Software-Entwicklung”
-layout: folge
-video: lygh1qKm7YU
+description: Christiane Floyd zählt zu den Pionier:innen der Informatik. Wir sprechen
+  über “menschenzentrierte Software-Entwicklung” sprechen, das  schon in den Achtzigern
+  wesentliche Elemente agiler Entwicklung umgesetzt hat.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-8754f3645b653b547696a86099&v=1625838476
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/ChristianeFloyd.mp3
-description: Christiane Floyd zählt zu den Pionier:innen der Informatik. Wir sprechen über “menschenzentrierte Software-Entwicklung” sprechen, das  schon in den Achtzigern wesentliche Elemente agiler Entwicklung umgesetzt hat.
-thumbnail: folge66.png
 tag: Agilität
+thumbnail: folge66.png
+title: Folge 66 - Prof. Christiane Floyd zu “menschenzentrierter Software-Entwicklung”
+video: lygh1qKm7YU
 ---
 
 Christiane Floyd zählt zu den Pionier:innen der Informatik - sie war

--- a/_posts/2021-07-16-folge67.md
+++ b/_posts/2021-07-16-folge67.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 67 - Qualitätsszenarien 
-layout: folge
-video: Shr23fY8gns
-sketchnote-video: 2LesJ9Nn79U
+description: Qualitätsszenarien sind ein hervorragendes Werkzeug, um Anforderungen
+  zu erfassen und basierend darauf Lösungen zu entwickeln.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-60f54b6eab9d9286359833&v=1626688471
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Qualitaetsszenarien(1).mp3
-description: Qualitätsszenarien sind ein hervorragendes Werkzeug, um Anforderungen zu erfassen und basierend darauf Lösungen zu entwickeln.
-thumbnail: folge67.png
+sketchnote-video: 2LesJ9Nn79U
 tags:
 - Qualität
 - Grundlagen
+thumbnail: folge67.png
+title: Folge 67 - Qualitätsszenarien
+video: Shr23fY8gns
 ---
 
 Architekt:innen müssen Lösungen entwickeln, die den technischen

--- a/_posts/2021-07-23-folge68.md
+++ b/_posts/2021-07-23-folge68.md
@@ -1,13 +1,17 @@
 ---
-title: Folge 68 - Der Schritt zur Software-Architekt:in mit Oliver Wehrens
-layout: folge
-video: f-aJogqqk6M
-sketchnote-video: pSM8Hhc8PFQ
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-a2ca7bfa39953f7c362ca7cc19&v=1627366032
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/OliverWehrensSchrittSoftwareArchitektin.mp3
 description: Wie wird man eigentlich Software-Architekt:in
-thumbnail: folge68.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-a2ca7bfa39953f7c362ca7cc19&v=1627366032
+guests:
+- Oliver Wehrens
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/OliverWehrensSchrittSoftwareArchitektin.mp3
+sketchnote-video: pSM8Hhc8PFQ
 tags: Karriere
+thumbnail: folge68.png
+title: Folge 68 - Der Schritt zur Software-Architekt:in mit Oliver Wehrens
+video: f-aJogqqk6M
 ---
 
 Wie wird man eigentlich Software-Architekt:in? Anhand von Fragen von

--- a/_posts/2021-07-30-folge69.md
+++ b/_posts/2021-07-30-folge69.md
@@ -1,12 +1,17 @@
 ---
-title: Folge 69 - Frontendarchitektur III - Integration mit Franziska Dessart, Joy Heron und Lucas Dohmen
-layout: folge
-video: FuOpO-QRcos
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-9ecf312e41d8efd71ef3c41142&v=1627650020
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/FrontendIII.mp3
 description: Wie und warum integriert man Web-Anwendungen miteinander
-thumbnail: folge69.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-9ecf312e41d8efd71ef3c41142&v=1627650020
+guests:
+- Franziska Dessart, Joy Heron und Lucas Dohmen
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/FrontendIII.mp3
 tag: Frontend
+thumbnail: folge69.png
+title: Folge 69 - Frontendarchitektur III - Integration mit Franziska Dessart, Joy
+  Heron und Lucas Dohmen
+video: FuOpO-QRcos
 ---
 
 In dieser Folge von Software Architektur im Stream sprechen wir

--- a/_posts/2021-08-06-folge70.md
+++ b/_posts/2021-08-06-folge70.md
@@ -1,13 +1,16 @@
 ---
-title: Folge 70 - Funktionale Programmierung - Beating the Average?
-layout: folge
-video: K7wHIYd2feo
-sketchnote-video: pQ1gmG3q-iU
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-fc37837f233433aec64d8819ab&v=1628490320
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/FunktionaleProgrammierung.mp3
 description: Paper "Beating the Average" über die Überlegenheit funktionaler Programmierung
-thumbnail: folge70.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-fc37837f233433aec64d8819ab&v=1628490320
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/FunktionaleProgrammierung.mp3
+sketchnote-video: pQ1gmG3q-iU
 tag: Funktionale Programmierung
+thumbnail: folge70.png
+title: Folge 70 - Funktionale Programmierung - Beating the Average?
+video: K7wHIYd2feo
 ---
 
 Funktionale Programmierung wird zwar immer populärer, aber auch heute

--- a/_posts/2021-08-13-folge71.md
+++ b/_posts/2021-08-13-folge71.md
@@ -1,13 +1,17 @@
 ---
-title: Folge 71 - Welchen Sinn hat agiles Coaching? mit Johannes Link
-layout: folge
-video: JKDfy7A61ug
-sketchnote-video: EzO1c4Z0dvw
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-631c8b3d9cb78710111b5f3f83&v=1628928992
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/AgilesCoaching.mp3
 description: Johannes Link hat agiles Coaching aufgegeben - warum?
-thumbnail: folge71.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-631c8b3d9cb78710111b5f3f83&v=1628928992
+guests:
+- Johannes Link
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/AgilesCoaching.mp3
+sketchnote-video: EzO1c4Z0dvw
 tag: Agilität
+thumbnail: folge71.png
+title: Folge 71 - Welchen Sinn hat agiles Coaching? mit Johannes Link
+video: JKDfy7A61ug
 ---
 
 Unternehmen, die modern sein wollen, müssen Software agil entwickeln

--- a/_posts/2021-08-27-folge72.md
+++ b/_posts/2021-08-27-folge72.md
@@ -1,12 +1,17 @@
 ---
-title: Folge 72 - Strategisches Domain-driven Design - Grundlegende Patterns unter der Lupe
-layout: folge
-video: 8Wr7QA1w5YE
+description: Ein genauer Blicka auf strategisches Domain-driven Design - Herausforderungen
+  und Missverständnisse
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-6ad8c1f22c98f2503b896a7ab6&v=1630066989
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/StrategicDomainDrivenDesignPatternsUnterDerLupe.mp3
-description: Ein genauer Blicka auf strategisches Domain-driven Design - Herausforderungen und Missverständnisse
-thumbnail: folge72.png
 tag: Domain-driven Design
+thumbnail: folge72.png
+title: Folge 72 - Strategisches Domain-driven Design - Grundlegende Patterns unter
+  der Lupe
+video: 8Wr7QA1w5YE
 ---
 
 Strategisches Domain-driven Design ist viel mehr als das Aufteilen

--- a/_posts/2021-09-03-folge73.md
+++ b/_posts/2021-09-03-folge73.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 73 - Das Spotify-Modell gibt es gar nicht!
-layout: folge
-video: I63tgkMCDUw
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-a511d8daf027bcfa23f9f8c194&v=1630679058
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Spotify.mp3
 description: Das Spotify-Modell ist erfolgreich - aber auch misverstanden.
-thumbnail: folge73.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-a511d8daf027bcfa23f9f8c194&v=1630679058
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Spotify.mp3
 tags:
 - Organisation
 - Agilität
+thumbnail: folge73.png
+title: Folge 73 - Das Spotify-Modell gibt es gar nicht!
+video: I63tgkMCDUw
 ---
 
 Spotify ist nicht nur eine beliebte Anwendung zum Streamen von Musik,


### PR DESCRIPTION
Add guest and moderator metadata for episodes 73, 72, 71, 70, 69, 68, 67, 66, 65, 64.

Batch 31 - systematically filling remaining gaps in issue #60.
Processed 10 episode files.

Notable guests extracted:
- Episode 71: Johannes Link
- Episode 69: Franziska Dessart, Joy Heron und Lucas Dohmen
- Episode 68: Oliver Wehrens

Changes:
- Added 'guests' field with extracted guest names or empty arrays
- Added 'moderators' field with ["Eberhard Wolff"]
- Systematic gap filling for complete #60 coverage