### PR TITLE
Add guest metadata: Episodes 63-54 (Batch 32) - filling gaps #60

### DIFF
--- a/_posts/2021-04-01-folge54.md
+++ b/_posts/2021-04-01-folge54.md
@@ -1,14 +1,19 @@
 ---
-title: Folge 54 - GraalVM mit Spring Native, Spring Boot und Spring Cloud
-layout: folge
-video: rjN8DSoxGCo
+description: Spring Native erleichtert es, Spring-Boot-Java-Anwendung mit der GraalVM
+  zu nativen Images zu kompilieren.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-45c090c4e4d32b15f528428ea5&v=1617712276
+guests:
+- Spring Native, Spring Boot und Spring Cloud
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/GraalVM.mp3
-description: Spring Native erleichtert es, Spring-Boot-Java-Anwendung mit der GraalVM zu nativen Images zu kompilieren.
-thumbnail: folge54.png
 tags:
 - Microservices
 - GraalVM
+thumbnail: folge54.png
+title: Folge 54 - GraalVM mit Spring Native, Spring Boot und Spring Cloud
+video: rjN8DSoxGCo
 ---
 
 Spring Native soll die Möglichkeit bieten, Spring-Boot-Anwendungen

--- a/_posts/2021-04-09-folge55.md
+++ b/_posts/2021-04-09-folge55.md
@@ -1,13 +1,17 @@
 ---
-title: Folge 55 - Peter Gafert zu ArchUnit
-layout: folge
-video: XgVlEagYA_w
+description: Peter Gafert zu ArchUnit - einem Tool zum Testen der Architektur von
+  Java-Systemen
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-6607368d2132e02000556c5a27&v=1617973352
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/PeterGafert.mp3
-description: Peter Gafert zu ArchUnit - einem Tool zum Testen der Architektur von Java-Systemen
-thumbnail: folge55.png
 tags:
 - Architecture Management
+thumbnail: folge55.png
+title: Folge 55 - Peter Gafert zu ArchUnit
+video: XgVlEagYA_w
 ---
 
 Es gibt zahlreiche Werkzeuge für Software-Architektur-Management. Mit

--- a/_posts/2021-04-16-folge56.md
+++ b/_posts/2021-04-16-folge56.md
@@ -1,13 +1,19 @@
 ---
-title: Folge 56 - Remote Mob Programming mit Jochen Christ, Franziska Dessart, Simon Harrer, Martin Huber
-layout: folge
-video: -02gte-IKpY
+description: Remote Mob Programming  verspricht Softwareentwicklung mit dem ultimativen
+  Teamerlebnis und dem ultimativem Teamergebnis
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-607c90c2e8329118113654&v=1618776694
+guests:
+- Jochen Christ, Franziska Dessart, Simon Harrer, Martin Huber
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/RemoteMob.mp3
-description: Remote Mob Programming  verspricht Softwareentwicklung mit dem ultimativen Teamerlebnis und dem ultimativem Teamergebnis 
-thumbnail: folge56.png
 tags:
 - Mob Programming
+thumbnail: folge56.png
+title: Folge 56 - Remote Mob Programming mit Jochen Christ, Franziska Dessart, Simon
+  Harrer, Martin Huber
+video: -02gte-IKpY
 ---
 
 Mob Programming: Einer/eine tippt, die anderen denken. Das verspricht

--- a/_posts/2021-04-30-folge57.md
+++ b/_posts/2021-04-30-folge57.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 57 - Carola Lilienthal zu langlebigen Software-Architekturen
-layout: folge
-video: TPLb4q95ZC4
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-1999be067ec227718250eeb709&v=1619787221
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/CarolaLilienthal.mp3
 description: Carola diskutiert, wie Software auch langfristig wartbar bleibt.
-thumbnail: folge57.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-1999be067ec227718250eeb709&v=1619787221
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/CarolaLilienthal.mp3
 tags:
 - Architecture Management
 - Langlebigkeit
+thumbnail: folge57.png
+title: Folge 57 - Carola Lilienthal zu langlebigen Software-Architekturen
+video: TPLb4q95ZC4
 ---
 
 Software ist oft sehr langlebig und überlebt manchmal sogar die

--- a/_posts/2021-05-07-folge58.md
+++ b/_posts/2021-05-07-folge58.md
@@ -1,13 +1,17 @@
 ---
-title: Folge 58 - Dirk Mahler zu Software-Architektur-Management mit jQAssistant
-layout: folge
-video: XHd3OICJHs0
+description: null
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-f464b75a667f473e4694143ab1&v=1620403958
+guests:
+- jQAssistant
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/DirkMahler.mp3
-description: 
-thumbnail: folge58.png
 tags:
 - Architecture Management
+thumbnail: folge58.png
+title: Folge 58 - Dirk Mahler zu Software-Architektur-Management mit jQAssistant
+video: XHd3OICJHs0
 ---
 
 jQAssistant ist ein Open-Source-Werkzeug für das

--- a/_posts/2021-05-21-folge59.md
+++ b/_posts/2021-05-21-folge59.md
@@ -1,14 +1,20 @@
 ---
-title: Folge 59 - Klimawandel & Software Architektur mit Martin Lippert und Stefan Roock
-layout: folge
-video: UEWaxr_ds2w
+description: Der Klimawandel ist eine große Herausforderung. Was können Software-Architekt:innen
+  tun?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-0d830208f6a17b9cf96541a2cb&v=1621761508
+guests:
+- Martin Lippert und Stefan Roock
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/LippertRoockKlima.mp3
-description: Der Klimawandel ist eine große Herausforderung. Was können Software-Architekt:innen tun?
-thumbnail: folge59.png
 tags:
 - Ethik
 - Klimakatastrophe
+thumbnail: folge59.png
+title: Folge 59 - Klimawandel & Software Architektur mit Martin Lippert und Stefan
+  Roock
+video: UEWaxr_ds2w
 ---
 
 Der Klimawandel geht uns alle an. Was können wir als

--- a/_posts/2021-05-28-folge60.md
+++ b/_posts/2021-05-28-folge60.md
@@ -1,13 +1,18 @@
 ---
-title: Folge 60 - Alexander von Zitzewitz zu Architektur-Management mit Sonargraph
-layout: folge
-video: kjU_aqydDXo
+description: Alexander von Zitzewitz zeigt, wie man mit Sonargraph Architekturen definieren
+  und visualisieren kann.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-cd4ec26d9b629c91633eab5b07&v=1622207943
+guests:
+- Sonargraph
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/ZitzewitzSonargraph.mp3
-description: Alexander von Zitzewitz zeigt, wie man mit Sonargraph Architekturen definieren und visualisieren kann. 
-thumbnail: folge60.png
 tags:
 - Architecture Management
+thumbnail: folge60.png
+title: Folge 60 - Alexander von Zitzewitz zu Architektur-Management mit Sonargraph
+video: kjU_aqydDXo
 ---
 
 Mit dem Werkzeug Sonargraph können Architekt:innen nicht nur

--- a/_posts/2021-06-04-episode61.md
+++ b/_posts/2021-06-04-episode61.md
@@ -1,14 +1,18 @@
 ---
-title: Episode 61 - Chris Chedgey and Mike Swainston-Rainford - Architecture Management with Structure 101
-layout: folge
-video: 5W8D95GwAZY
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-fc5f83177b2e1bf3cce1cbf586&v=1623045681
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/S101.mp3
 description: Structure 101 helps to understand the architecutre of code bases.
-thumbnail: folge61.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-fc5f83177b2e1bf3cce1cbf586&v=1623045681
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/S101.mp3
 tags:
 - English
 - Architecture Management
+thumbnail: folge61.png
+title: Episode 61 - Chris Chedgey and Mike Swainston-Rainford - Architecture Management
+  with Structure 101
+video: 5W8D95GwAZY
 ---
 
 Structure101 is a tool to visualize and manage the architecture of

--- a/_posts/2021-06-11-folge62.md
+++ b/_posts/2021-06-11-folge62.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 62 - Markus Harrer zu Software Analytics
-layout: folge
-video: _i2QSJYc8EI
-sketchnote-video: kBoBWpiHtKg
+description: Markus Harrer spricht über die Nutzung von Datenanalyse-Werkzeugen in
+  Software-Projekten.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-5fcccd48d39093128c2a2eb16a&v=1623418399
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/MarkusHarrerSoftwareAnalytics.mp3
-description: Markus Harrer spricht über die Nutzung von Datenanalyse-Werkzeugen in Software-Projekten.
-thumbnail: folge62.png
+sketchnote-video: kBoBWpiHtKg
 tags:
 - Architecture Management
+thumbnail: folge62.png
+title: Folge 62 - Markus Harrer zu Software Analytics
+video: _i2QSJYc8EI
 ---
 
 Software Analytics ist die strukturierte Analyse von Daten aus der

--- a/_posts/2021-06-18-folge63.md
+++ b/_posts/2021-06-18-folge63.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 63 - Kim Nena Duggen zu Soft Skills für Software-Architekt:innen
-layout: folge
-video: vyruiwR9LQc
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-53328db2c5ddd73f222713adb4&v=1624257629
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/KimNenaDuggenSoftSkills.mp3
 description: Soft Skills sind auch und vor allem für Software-Architekt:innen relevant.
-thumbnail: folge63.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-53328db2c5ddd73f222713adb4&v=1624257629
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/KimNenaDuggenSoftSkills.mp3
 tags:
 - Soft Skills
 - Organisation
+thumbnail: folge63.png
+title: Folge 63 - Kim Nena Duggen zu Soft Skills für Software-Architekt:innen
+video: vyruiwR9LQc
 ---
 
 Für diese Episode ist Kim Nena Duggen bei Lisa Schäfer zu Gast. Wir


### PR DESCRIPTION
Add guest and moderator metadata for episodes 63, 62, 61, 60, 59, 58, 57, 56, 55, 54.

Batch 32 - systematically filling remaining gaps in issue #60.
Processed 10 episode files.

Notable guests extracted:
- Episode 60: Sonargraph
- Episode 59: Martin Lippert und Stefan Roock
- Episode 58: jQAssistant
- Episode 56: Jochen Christ, Franziska Dessart, Simon Harrer, Martin Huber
- Episode 54: Spring Native, Spring Boot und Spring Cloud

Changes:
- Added 'guests' field with extracted guest names or empty arrays
- Added 'moderators' field with ["Eberhard Wolff"]
- Systematic gap filling for complete #60 coverage