### PR TITLE
Add guest metadata: Episodes 215, 184, 141-104 (Batch 25 - 40 episodes) - filling gaps #60

### DIFF
--- a/_posts/2022-02-01-folge104.md
+++ b/_posts/2022-02-01-folge104.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 104 - Erik Dörnenburg - DevSecOps - live von der OOP
-layout: folge
-video: C2fJ5TqMxIM
-peertube: https://tube.tchncs.de/videos/embed/4e23a60e-251d-4736-a419-5ac6549a8dbd
+description: Wir kennen alle DevOps - aber was ist DevSecOps und warum gehört ausgerechnet
+  Sicherheit dazu?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-d12567406c025b77faf4170631&v=1643733147
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Erik_Doernenburg_DevSecOps.mp3
-description: Wir kennen alle DevOps - aber was ist DevSecOps und warum gehört ausgerechnet Sicherheit dazu?
-thumbnail: OOP2022.png
+peertube: https://tube.tchncs.de/videos/embed/4e23a60e-251d-4736-a419-5ac6549a8dbd
 tags:
 - DevSecOps
 - Live von der OOP
+thumbnail: OOP2022.png
+title: Folge 104 - Erik Dörnenburg - DevSecOps - live von der OOP
+video: C2fJ5TqMxIM
 ---
 
 Wir kennen alle DevOps - aber was ist DevSecOps und warum gehört

--- a/_posts/2022-02-01-folge105.md
+++ b/_posts/2022-02-01-folge105.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 105 - Lucas Dohmen, Lars Hupel - Hilfe, wir syncen! - live von der OOP
-layout: folge
-video: glCrvR2MYxM
-peertube: https://tube.tchncs.de/videos/embed/fed467ba-3cb4-44cd-9b6b-0e2780c02ece
+description: Daten beispielsweise lokal zu kopieren, um offline zu arbeiten, ist eine
+  Herausforderung. Wir diskutieren, wie man sie meistern kann.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-9cda909ea7c72d2b2f7101204d&v=1643734572
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Lucas_Dohmen_Lars_Hupel_Hilfe_wir_syncen.mp3
-description: Daten beispielsweise lokal zu kopieren, um offline zu arbeiten, ist eine Herausforderung. Wir diskutieren, wie man sie meistern kann.
-thumbnail: OOP2022.png
+peertube: https://tube.tchncs.de/videos/embed/fed467ba-3cb4-44cd-9b6b-0e2780c02ece
 tags:
 - Live von der OOP
 - CRDT
+thumbnail: OOP2022.png
+title: Folge 105 - Lucas Dohmen, Lars Hupel - Hilfe, wir syncen! - live von der OOP
+video: glCrvR2MYxM
 ---
 
 Daten beispielsweise lokal zu kopieren, um offline zu arbeiten, ist

--- a/_posts/2022-02-01-folge106.md
+++ b/_posts/2022-02-01-folge106.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 106 - Anne Herwanger, Alexandra Hoitz, Stefan Link - Resiliente Organisation und resiliente Software Architektur - live von der OOP
-layout: folge
-video: BTURNT7EQhk
-peertube: https://tube.tchncs.de/videos/embed/8c7dbdb6-6a0f-40e1-8f0c-31e2cf7eeeb5
+description: Die Organisation hat großen Einfluss auf die Architektur. Wie kann man
+  sich diesen Zusammenhang zu Nutze machen?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-0e775e30d8bdd18eca5f8ac9ab&v=1643736061
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Resiliente_Organisation_und_resiliente_Software-Architektur.mp3
-description: Die Organisation hat großen Einfluss auf die Architektur. Wie kann man sich diesen Zusammenhang zu Nutze machen?
-thumbnail: OOP2022.png
+peertube: https://tube.tchncs.de/videos/embed/8c7dbdb6-6a0f-40e1-8f0c-31e2cf7eeeb5
 tags:
 - Live von der OOP
 - Organisation
+thumbnail: OOP2022.png
+title: Folge 106 - Anne Herwanger, Alexandra Hoitz, Stefan Link - Resiliente Organisation
+  und resiliente Software Architektur - live von der OOP
+video: BTURNT7EQhk
 ---
 
 Resiliente Organisation und resiliente Software-Architektur: Die

--- a/_posts/2022-02-02-folge107.md
+++ b/_posts/2022-02-02-folge107.md
@@ -1,16 +1,21 @@
 ---
-title: Folge 107 - Klima-Panel mit Marina Köhn, Jutta Eckstein, Max Schulze - live von der OOP!
-layout: folge
-video: SQ3sbRXK8iM
-peertube: https://tube.tchncs.de/videos/embed/88c41b7a-a560-468a-a424-7e0aaa1de151
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-1f7707f1c8a1124db68644df97&v=1643821883
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/KlimaPanel.mp3
 description: Wie kann Software-Architektur im Kampf gegen die Klima-Katastrophe helfen?
-thumbnail: OOP2022-klima.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-1f7707f1c8a1124db68644df97&v=1643821883
+guests:
+- Marina Köhn, Jutta Eckstein, Max Schulze - live von der OOP!
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/KlimaPanel.mp3
+peertube: https://tube.tchncs.de/videos/embed/88c41b7a-a560-468a-a424-7e0aaa1de151
 tags:
 - Live von der OOP
 - Klimakatastrophe
 - Ethik
+thumbnail: OOP2022-klima.png
+title: Folge 107 - Klima-Panel mit Marina Köhn, Jutta Eckstein, Max Schulze - live
+  von der OOP!
+video: SQ3sbRXK8iM
 ---
 
 Die Klima-Katastrophe ist eine der wichtigsten

--- a/_posts/2022-02-03-folge108.md
+++ b/_posts/2022-02-03-folge108.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 108 -  Katrin Rabow, Nicola Marsden, Silke Foth - Diversity-Panel - live von der OOP
-layout: folge
-video: wBjUkCGFwhU
+description: Wie kann Diversityhttps://1evriw.podcaster.de/software-architektur-im-stream/media/DiversityPanel.mp3
+  in der Software-Entwicklung erhöht werden?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-71cde552657d6f1a1b5ef484ff&v=1643896175
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/DiversityPanel.mp3
 peertube: https://tube.tchncs.de/videos/embed/ef06e5d8-76e5-4329-8c5a-2c5fdea7ab57
-description: Wie kann Diversityhttps://1evriw.podcaster.de/software-architektur-im-stream/media/DiversityPanel.mp3 in der Software-Entwicklung erhöht werden?
-thumbnail: OOP2022-diversity.png
 tags:
 - Diversity
 - Live von der OOP
+thumbnail: OOP2022-diversity.png
+title: Folge 108 -  Katrin Rabow, Nicola Marsden, Silke Foth - Diversity-Panel - live
+  von der OOP
+video: wBjUkCGFwhU
 ---
 
 In der Software-Entwicklung sind zahlreiche Gruppen

--- a/_posts/2022-02-11-folge109.md
+++ b/_posts/2022-02-11-folge109.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 109 - Was ist Software-Architektur überhaupt?
+description: Wir diskutieren, was Software-Architektur ist anhand von Definitionen
+  und Tweets.
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-4948e59294e64abd72ae820f93&v=1644669795
+guests: []
 layout: folge
-video: lFOjTKDdp8c
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/WasIstSoftwareArchitekturUeberhaupt.mp3
 peertube: https://tube.tchncs.de/videos/embed/8d2129fc-32eb-4e72-bdd5-dfb2002f5881
 sketchnote-video: e-W9_G2UWHo
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-4948e59294e64abd72ae820f93&v=1644669795
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/WasIstSoftwareArchitekturUeberhaupt.mp3
-description: Wir diskutieren, was Software-Architektur ist anhand von Definitionen und Tweets.
-thumbnail: folge109.png
 tags:
 - Grundlagen
+thumbnail: folge109.png
+title: Folge 109 - Was ist Software-Architektur überhaupt?
+video: lFOjTKDdp8c
 ---
 
 Software-Architektur im Stream hat jetzt über 100 Folgen - aber eine

--- a/_posts/2022-02-18-folge110.md
+++ b/_posts/2022-02-18-folge110.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 110 - Conway's Law
-layout: folge
-video: 7qJp_CXAezU
-peertube: https://tube.tchncs.de/videos/embed/88f00b66-8eb2-4fc8-a663-9380d18e1032
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-e6c7ecb6ebb48aec4b867ac374&v=1645360670
-mp3: https://1evriw.podcaster.de/download/ConwaysLaw.mp3?origin=embed
 description: Was besagt das Gesetz von Conway / Conway's Law genau?
-thumbnail: folge110.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-e6c7ecb6ebb48aec4b867ac374&v=1645360670
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/download/ConwaysLaw.mp3?origin=embed
+peertube: https://tube.tchncs.de/videos/embed/88f00b66-8eb2-4fc8-a663-9380d18e1032
 tags:
 - Organisation
+thumbnail: folge110.png
+title: Folge 110 - Conway's Law
+video: 7qJp_CXAezU
 ---
 
 Das Gesetz von Conway stellt einen Zusammenhang zwischen der

--- a/_posts/2022-02-25-folge111.md
+++ b/_posts/2022-02-25-folge111.md
@@ -1,16 +1,19 @@
 ---
-title: Folge 111 - Wir bauen eine Sofware-Architektur
-layout: folge
-video: -FCkp1aJzRY
-peertube: https://tube.tchncs.de/videos/embed/612aeccd-0e38-4457-b9c8-3db1d1c2563c
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-26a6b7bb3be852427d48eba367&v=1646073315
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/WirBauenEineSoftwareArchitektur-xcf.mp3
 description: In dieser Episode erstellen wir eine Software-Architektur - live!
-thumbnail: folge111.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-26a6b7bb3be852427d48eba367&v=1646073315
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/WirBauenEineSoftwareArchitektur-xcf.mp3
+peertube: https://tube.tchncs.de/videos/embed/612aeccd-0e38-4457-b9c8-3db1d1c2563c
 tags:
 - Grundlagen
 - Qualität
 - Wir bauen eine Software-Architektur
+thumbnail: folge111.png
+title: Folge 111 - Wir bauen eine Sofware-Architektur
+video: -FCkp1aJzRY
 ---
 
 In dieser Episode erstellen wir eine Software-Architektur live. So

--- a/_posts/2022-03-11-folge112.md
+++ b/_posts/2022-03-11-folge112.md
@@ -1,16 +1,19 @@
 ---
-title: Folge 112 - Wir bauen eine Software-Architektur - Struktur der Lösung
+description: Wir bauen die Struktur der beispielhaften Software-Architektur.
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-d063844c519b9221e10c3e868e&v=1647196300
+guests: []
 layout: folge
-video: K512HtCbb2Q
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/WirBauenEineSoftwareArchitekturStrukturDerLoesung.mp3
 peertube: https://tube.tchncs.de/videos/embed/22fe5130-ce78-4e9d-9f26-960661a069f6
 sketchnote-video: SR7rEQ7nSzg
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-d063844c519b9221e10c3e868e&v=1647196300
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/WirBauenEineSoftwareArchitekturStrukturDerLoesung.mp3
-description: Wir bauen die Struktur der beispielhaften Software-Architektur.
-thumbnail: folge111.png
 tags:
 - Grundlagen
 - Wir bauen eine Software-Architektur
+thumbnail: folge111.png
+title: Folge 112 - Wir bauen eine Software-Architektur - Struktur der Lösung
+video: K512HtCbb2Q
 ---
 
 Nachdem wir in der [vorherigen Episode](/2022/02/25/folge111.html)

--- a/_posts/2022-03-25-folge113.md
+++ b/_posts/2022-03-25-folge113.md
@@ -1,17 +1,20 @@
 ---
-title: Folge 113 - Qualitäten / nicht-funktionale Anforderungen umsetzen - Wir bauen eine Software-Architektur
+description: Wir suchen Lösungen für die Qualitätsszenarien.
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-dd2e7c984071a881b9e9e996ad&v=1648216524
+guests: []
 layout: folge
-video: oteC-_RZzPk
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Qualitaeten_nicht-funktionale_Anforderungen_umsetzen_-_Wir_bauen_eine_Software-Architektur.mp3
 peertube: https://tube.tchncs.de/videos/embed/9a804c23-007d-4119-9781-ead43ed0d436
 sketchnote-video: VCLfh1mWP00
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-dd2e7c984071a881b9e9e996ad&v=1648216524
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Qualitaeten_nicht-funktionale_Anforderungen_umsetzen_-_Wir_bauen_eine_Software-Architektur.mp3
-description: Wir suchen Lösungen für die Qualitätsszenarien.
-thumbnail: folge111.png
 tags:
 - Grundlagen
 - Wir bauen eine Software-Architektur
-
+thumbnail: folge111.png
+title: Folge 113 - Qualitäten / nicht-funktionale Anforderungen umsetzen - Wir bauen
+  eine Software-Architektur
+video: oteC-_RZzPk
 ---
 
 In den [letzten](/2022/02/25/folge111.html)

--- a/_posts/2022-04-01-folge114.md
+++ b/_posts/2022-04-01-folge114.md
@@ -1,18 +1,22 @@
 ---
-title: Folge 114 -  Benutzerfreundlichkeit mit Aminata Sidibe - Wir bauen eine Software-Architektur
-layout: folge
-video: 6kypcTVBmMc
-peertube: https://tube.tchncs.de/videos/embed/f05a274b-0e94-4abf-bd63-3e296b180e1e
-sketchnote-video: 
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-5963d80020ee6def1a86dcf7c1&v=1648826367
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Benutzerfreundlichkeit_mit_Aminata_Sidibe_-_Wir_bauen_eine_Software-Architektur.mp3
 description: Aminata Sidibe erläutern Konzepte für Benutzerfreundlichkeit.
-thumbnail: folge114.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-5963d80020ee6def1a86dcf7c1&v=1648826367
+guests:
+- Aminata Sidibe - Wir bauen eine Software-Architektur
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Benutzerfreundlichkeit_mit_Aminata_Sidibe_-_Wir_bauen_eine_Software-Architektur.mp3
+peertube: https://tube.tchncs.de/videos/embed/f05a274b-0e94-4abf-bd63-3e296b180e1e
+sketchnote-video: null
 tags:
 - UX
 - Benutzerfreundlichkeit
 - Wir bauen eine Software-Architektur
 - Grundlagen
+thumbnail: folge114.png
+title: Folge 114 -  Benutzerfreundlichkeit mit Aminata Sidibe - Wir bauen eine Software-Architektur
+video: 6kypcTVBmMc
 ---
 
 Weiter geht es mit dem Enturf unserer Architektur aus den letzten

--- a/_posts/2022-04-08-folge115.md
+++ b/_posts/2022-04-08-folge115.md
@@ -1,15 +1,18 @@
 ---
-title: Folge 115 - Data Mesh - nur ein neuer Datenanalyse-Hype?
-layout: folge
-video: 16Is187H7wc
-peertube: https://tube.tchncs.de/videos/embed/4a9c4cff-9f03-40b7-aebd-ea9717b7580e
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-3cc3db935afca84ab9bb4134bb&v=1649603483
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Data_Mesh_-_nur_ein_neuer_Datenanalyse-Hype-1.mp3
 description: Data Mesh ist ein neue Ansatz für dezentrale Datenanalyse.
-thumbnail: folge115.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-3cc3db935afca84ab9bb4134bb&v=1649603483
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Data_Mesh_-_nur_ein_neuer_Datenanalyse-Hype-1.mp3
+peertube: https://tube.tchncs.de/videos/embed/4a9c4cff-9f03-40b7-aebd-ea9717b7580e
 tags:
 - Data Mesh
 - Organisation
+thumbnail: folge115.png
+title: Folge 115 - Data Mesh - nur ein neuer Datenanalyse-Hype?
+video: 16Is187H7wc
 ---
 
 

--- a/_posts/2022-04-22-folge116.md
+++ b/_posts/2022-04-22-folge116.md
@@ -1,18 +1,22 @@
 ---
-title: Folge 116 - Events, Event Sourcing und CQRS
-layout: folge
-video: 4xxwX52MLLI
-peertube: https://tube.tchncs.de/videos/embed/2317676f-5c13-413e-a11f-1ede886f4716
+description: Verschiedene Facetten von Events bei DDD, Event Sourcing, Event Storming
+  und CQRS
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-4136a50a0ad32caa5a13a8930d&v=1650732204
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Events-_Event_Sourcing_und_CQRS.mp3
-description: Verschiedene Facetten von Events bei DDD, Event Sourcing, Event Storming und CQRS 
-thumbnail: folge116.png
+peertube: https://tube.tchncs.de/videos/embed/2317676f-5c13-413e-a11f-1ede886f4716
 tags:
 - Domain-driven Design
 - Events
 - Event Storming
 - Event Sourcing
 - CQRS
+thumbnail: folge116.png
+title: Folge 116 - Events, Event Sourcing und CQRS
+video: 4xxwX52MLLI
 ---
 
 Events sind ein wichtiges Element vieler Architekturen. Sie spielen in

--- a/_posts/2022-04-29-folge117.md
+++ b/_posts/2022-04-29-folge117.md
@@ -1,17 +1,20 @@
 ---
-title: Folge 117 - Eine Architektur entwerfen - iSAQB Advanced Beispielaufgabe
-layout: folge
-video: VspImCV5mi8
-peertube: https://tube.tchncs.de/videos/embed/215beb92-5be9-4994-a075-b4b1da76d9ca
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-a41ea23f62f4a739870b5f89ca&v=1651252557
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Architektur_entwerfen_iSAQB_Advanced_Beispielaufgabe.mp3
 description: Lösung zur iSAQB Beispielaufgabe Big Spender
-thumbnail: folge117.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-a41ea23f62f4a739870b5f89ca&v=1651252557
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Architektur_entwerfen_iSAQB_Advanced_Beispielaufgabe.mp3
+peertube: https://tube.tchncs.de/videos/embed/215beb92-5be9-4994-a075-b4b1da76d9ca
 tags:
 - iSAQB
 - Grundlagen
 - Qualität
 - iSAQB Advanced Beispielaufgabe
+thumbnail: folge117.png
+title: Folge 117 - Eine Architektur entwerfen - iSAQB Advanced Beispielaufgabe
+video: VspImCV5mi8
 ---
 
 Wie erstellt man denn nun eine Software-Architektur? In dieser Episode

--- a/_posts/2022-05-06-folge118.md
+++ b/_posts/2022-05-06-folge118.md
@@ -1,16 +1,19 @@
 ---
-title: Folge 118 - Lösungsstrategie - iSAQB Advanced Beispielaufgabe
-layout: folge
-video: 1w__FCeDOQs
-peertube: https://tube.tchncs.de/videos/embed/b137813f-5d7a-4d61-b1a6-3bd5cb409296
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-e969d540df59356a60333684f4&v=1651840827
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Loesungsstrategie_Kontext_iSAQB_Advanced_Beispielaufgabe.mp3
 description: Lösungsstragie für die iSAQB Advanced Beispielsaufgabe
-thumbnail: folge118.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-e969d540df59356a60333684f4&v=1651840827
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Loesungsstrategie_Kontext_iSAQB_Advanced_Beispielaufgabe.mp3
+peertube: https://tube.tchncs.de/videos/embed/b137813f-5d7a-4d61-b1a6-3bd5cb409296
 tags:
 - iSAQB
 - Grundlagen
 - iSAQB Advanced Beispielaufgabe
+thumbnail: folge118.png
+title: Folge 118 - Lösungsstrategie - iSAQB Advanced Beispielaufgabe
+video: 1w__FCeDOQs
 ---
 
 Nach der [letzten Episode](/2022/04/29/folge117.html) geht es weiter

--- a/_posts/2022-05-13-folge119.md
+++ b/_posts/2022-05-13-folge119.md
@@ -1,15 +1,18 @@
 ---
-title: Folge 119 - Gibt es das Wasserfallmodell überhaupt?
-layout: folge
-video: ufceCTDC2lM
-peertube: https://tube.tchncs.de/videos/embed/5ac9be1b-cdd4-4851-8b34-10765da98fae
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-e2f1d20ba3ff1ba16f2eb43812&v=1652465761
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Gibt_es_das_Wasserfallmodell_ueberhaupt.mp3
 description: Gibt es das Wasserfall-Modell? Ist es sinnvoll?
-thumbnail: folge119.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-e2f1d20ba3ff1ba16f2eb43812&v=1652465761
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Gibt_es_das_Wasserfallmodell_ueberhaupt.mp3
+peertube: https://tube.tchncs.de/videos/embed/5ac9be1b-cdd4-4851-8b34-10765da98fae
 tags:
 - Wasserfall
 - Agilität
+thumbnail: folge119.png
+title: Folge 119 - Gibt es das Wasserfallmodell überhaupt?
+video: ufceCTDC2lM
 ---
 
 Software entwickelt man heutzutage agil - die einzige Alternative wäre

--- a/_posts/2022-05-20-folge120.md
+++ b/_posts/2022-05-20-folge120.md
@@ -1,16 +1,19 @@
 ---
-title: Folge 120 - Technischer Kontext und fachliche Aufteilung - iSAQB Advanced Beispielaufgabe 
-layout: folge
-video: WEiQ0Uj7J6k
-peertube: https://tube.tchncs.de/videos/embed/53670c4c-a4b4-4a8a-9ca6-bc7a295ca983
+description: null
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-10ef08c8822bf110c910c8ae5a&v=1653052758
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/download/Technischer_Kontext_-_iSAQB_Advanced_Beispielaufgabe.mp3?origin=embed
-description: 
-thumbnail: folge118.png
+peertube: https://tube.tchncs.de/videos/embed/53670c4c-a4b4-4a8a-9ca6-bc7a295ca983
 tags:
 - iSAQB
 - Grundlagen
 - iSAQB Advanced Beispielaufgabe
+thumbnail: folge118.png
+title: Folge 120 - Technischer Kontext und fachliche Aufteilung - iSAQB Advanced Beispielaufgabe
+video: WEiQ0Uj7J6k
 ---
 
 Es geht weiter mit der iSAQB Advanced Beispielaufgabe "Big Spender"!

--- a/_posts/2022-06-03-folge121.md
+++ b/_posts/2022-06-03-folge121.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 121 - Airbnb-Architektur 
-layout: folge
-video: Dh9CgeC4xiI
-peertube: https://tube.tchncs.de/videos/embed/3ff03541-08fe-453f-88ac-1e46bc305eb0
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-26c3565e6fdae216e1fbcb7397&v=1654260044
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Airbnb_Architektur.mp3
 description: Eine Diskussion der Airbnb-Architektur
-thumbnail: folge121.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-26c3565e6fdae216e1fbcb7397&v=1654260044
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Airbnb_Architektur.mp3
+peertube: https://tube.tchncs.de/videos/embed/3ff03541-08fe-453f-88ac-1e46bc305eb0
 tags:
 - Microservices
+thumbnail: folge121.png
+title: Folge 121 - Airbnb-Architektur
+video: Dh9CgeC4xiI
 ---
 
 Airbnb ermöglicht es, Zimmer und Wohnung an Touristen und andere zu

--- a/_posts/2022-06-10-folge122.md
+++ b/_posts/2022-06-10-folge122.md
@@ -1,16 +1,20 @@
 ---
-title: Folge 122 - DORA Metriken & Accelerate mit Felix Müller
-layout: folge
-video: Z2aMzqjEoTI
-peertube: https://tube.tchncs.de/videos/embed/1625079f-9286-43b4-ac5d-be81dee20ab6
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-6099508260ffc5c85458005f4&v=1654867011
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/DORA_Metriken_und_Accelerate_mit_Felix_Mueller.mp3
 description: Felix Müller diskutiert DORA Metriken und Accelerate
-thumbnail: folge122.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-6099508260ffc5c85458005f4&v=1654867011
+guests:
+- Felix Müller
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/DORA_Metriken_und_Accelerate_mit_Felix_Mueller.mp3
+peertube: https://tube.tchncs.de/videos/embed/1625079f-9286-43b4-ac5d-be81dee20ab6
 tags:
 - Continuous Delivery
 - DORA
 - Empirical Software Engineering
+thumbnail: folge122.png
+title: Folge 122 - DORA Metriken & Accelerate mit Felix Müller
+video: Z2aMzqjEoTI
 ---
 
 Wie wird man bei der Software-Entwicklung besser? Dazu gibt es

--- a/_posts/2022-06-17-folge123.md
+++ b/_posts/2022-06-17-folge123.md
@@ -1,16 +1,19 @@
 ---
-title: Folge 123 - Technologie-Entscheidungen & Bewertung - iSAQB Advanced Beispielaufgabe 
-layout: folge
-video: ppzbbNNU9FI
-peertube: https://tube.tchncs.de/videos/embed/0da18963-8180-429f-a5cb-8c3ba6fa60da
+description: Technologie-Entscheidungen & Bewertung - iSAQB Advanced Beispielaufgabe
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-4611427326704aad901fdc5caa&v=1655471288
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Technologie-Entscheidungen_Bewertung_iSAQB_Advanced_Beispielaufgabe.mp3
-description: Technologie-Entscheidungen & Bewertung - iSAQB Advanced Beispielaufgabe 
-thumbnail: folge118.png
+peertube: https://tube.tchncs.de/videos/embed/0da18963-8180-429f-a5cb-8c3ba6fa60da
 tags:
 - iSAQB
 - Grundlagen
 - iSAQB Advanced Beispielaufgabe
+thumbnail: folge118.png
+title: Folge 123 - Technologie-Entscheidungen & Bewertung - iSAQB Advanced Beispielaufgabe
+video: ppzbbNNU9FI
 ---
 
  

--- a/_posts/2022-06-23-folge124.md
+++ b/_posts/2022-06-23-folge124.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 124 - Microservices - Schlag den Eberhard & Stefan! Mit Stefan Toth
-layout: folge
-video: GplG9Zz74ro
+description: Stefan Toth und Eberhard Wolff zum Streitgespräch über verschieden Architektur-Aspekte
+  von Microservices
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-425e832ddd0d5135bbe8efeaee&v=1656082146
+guests:
+- Stefan Toth
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Microservices_Schlag_den_Stefan_und_Eberhard.mp3
-description: Stefan Toth und Eberhard Wolff zum Streitgespräch über verschieden Architektur-Aspekte von Microservices
-thumbnail: folge124.png
 peertube: https://tube.tchncs.de/videos/embed/49fcdc45-33e7-4bb7-8bc1-b94a2a88bf4e
 tags:
 - Microservices
 - Kontroverse
+thumbnail: folge124.png
+title: Folge 124 - Microservices - Schlag den Eberhard & Stefan! Mit Stefan Toth
+video: GplG9Zz74ro
 ---
 
 Wie groß sollen Microservices sein? Wie autonom sollen Teams sein? Bei

--- a/_posts/2022-07-01-folge125.md
+++ b/_posts/2022-07-01-folge125.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 125 - Organisation und Architektur - ein Beispiel 
-layout: folge
-video: Pd3P_oOMKvM
-peertube: https://tube.tchncs.de/videos/embed/15d991c9-cb99-4887-8baf-79e8521d49fa
+description: Anhand eines Beispiels diskutiert Eberhard, wie Organisation und Architektur
+  zusammenhängen.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-271eaf9d5ee6d5707a2bd48e0c&v=1656699130
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Organisation_und_Architektur_-_ein_Beispiel.mp3
-description: Anhand eines Beispiels diskutiert Eberhard, wie Organisation und Architektur zusammenhängen.
-thumbnail: folge125.png
+peertube: https://tube.tchncs.de/videos/embed/15d991c9-cb99-4887-8baf-79e8521d49fa
 tags:
 - Organisation
 - Soziotechnische Systeme
+thumbnail: folge125.png
+title: Folge 125 - Organisation und Architektur - ein Beispiel
+video: Pd3P_oOMKvM
 ---
 
 Organisation und Architektur hängen sehr eng zusammen. Welche

--- a/_posts/2022-07-07-folge126.md
+++ b/_posts/2022-07-07-folge126.md
@@ -1,15 +1,18 @@
 ---
-title: Folge 126 - Die Rolle "Software-Architekt:in" - Folge 1
-layout: folge
-video: 1nj0uoXDxTA
-peertube: https://tube.tchncs.de/videos/embed/0a8b1fda-309f-416e-be2c-d9edbef3644a
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-92a8a59ce4ad85c86647d3c41c&v=1657198452
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/RolleSoftwareArchitektin.mp3
 description: Wie lebt man die Rolle einer Software-Architektin?
-thumbnail: folge126.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-92a8a59ce4ad85c86647d3c41c&v=1657198452
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/RolleSoftwareArchitektin.mp3
+peertube: https://tube.tchncs.de/videos/embed/0a8b1fda-309f-416e-be2c-d9edbef3644a
 tags:
 - Grundlagen
 - Rolle Software-Architektin
+thumbnail: folge126.png
+title: Folge 126 - Die Rolle "Software-Architekt:in" - Folge 1
+video: 1nj0uoXDxTA
 ---
 
 Was macht eine Software-Architekt:in eigentlich genau? Irgendwie ist

--- a/_posts/2022-07-15-folge127.md
+++ b/_posts/2022-07-15-folge127.md
@@ -1,15 +1,18 @@
 ---
-title: Folge 127 - Die Rolle "Software-Architekt:in" - Folge 2
-layout: folge
-video: thIkj_YWnBc
-peertube: https://tube.tchncs.de/videos/embed/c8a1088a-24f6-4345-a94d-bbc128d78bef
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-9b6778ca3adb5d8db08c1e3c86&v=1657887494
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/RolleSoftwareArchitektin_-_Folge_2.mp3
 description: Wie lebt man die Rolle einer Software-Architektin?
-thumbnail: folge127.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-9b6778ca3adb5d8db08c1e3c86&v=1657887494
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/RolleSoftwareArchitektin_-_Folge_2.mp3
+peertube: https://tube.tchncs.de/videos/embed/c8a1088a-24f6-4345-a94d-bbc128d78bef
 tags:
 - Grundlagen
 - Rolle Software-Architektin
+thumbnail: folge127.png
+title: Folge 127 - Die Rolle "Software-Architekt:in" - Folge 2
+video: thIkj_YWnBc
 ---
 
 Nachdem in der letzten Folge noch zahlreiche Fragen unbeantwortet

--- a/_posts/2022-07-22-folge128.md
+++ b/_posts/2022-07-22-folge128.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 128 - Agilität und Architektur mit Stefan Toth
-layout: folge
-video: CW9wXAnwJIU
-peertube: https://tube.tchncs.de/videos/embed/043fd650-6506-4716-b16d-cc878397d786
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-3fe7c0f54897825ac1e1dfd464&v=1658494330
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Agilitaet_und_Architektur_mit_Stefan_Toth.mp3
 description: Stefan Toth spricht darüber, wie Architektur in agilen Projekten funktioniert.
-thumbnail: folge128.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-3fe7c0f54897825ac1e1dfd464&v=1658494330
+guests:
+- Stefan Toth
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Agilitaet_und_Architektur_mit_Stefan_Toth.mp3
+peertube: https://tube.tchncs.de/videos/embed/043fd650-6506-4716-b16d-cc878397d786
 tags:
 - Agilität
 - Rolle Software-Architektin
+thumbnail: folge128.png
+title: Folge 128 - Agilität und Architektur mit Stefan Toth
+video: CW9wXAnwJIU
 ---
 
 Architektur ist stabil, Software-Entwicklung ist agil - dauernd gibt

--- a/_posts/2022-07-29-folge129.md
+++ b/_posts/2022-07-29-folge129.md
@@ -1,15 +1,18 @@
 ---
-title: Folge 129 - Software-Architektur und Ethik
-layout: folge
-video: sdeNks9YClU
-peertube: https://tube.tchncs.de/videos/embed/639313d9-7f09-4089-bbc3-960a83a58033
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-800155dc84a9ac58ee4609eb42&v=1659112164
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Software_Architektur_und_Ethik.mp3
 description: Praktische Diskussion zur Ethik bei der Software-Architektur
-thumbnail: folge129.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-800155dc84a9ac58ee4609eb42&v=1659112164
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Software_Architektur_und_Ethik.mp3
+peertube: https://tube.tchncs.de/videos/embed/639313d9-7f09-4089-bbc3-960a83a58033
 tags:
 - Ethik
 - Diversity
+thumbnail: folge129.png
+title: Folge 129 - Software-Architektur und Ethik
+video: sdeNks9YClU
 ---
 
 Software-Architekt:innen sollten sich die Frage stellen, welche Arten

--- a/_posts/2022-08-05-folge130.md
+++ b/_posts/2022-08-05-folge130.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 130 - Ask Me Anything
-layout: folge
-video: 6D_OgQ9A6CU
-peertube: https://tube.tchncs.de/videos/embed/c192f0fe-f1d5-42f1-b684-38731fb26af5
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-15e9cd064d66ea890c754889ac&v=1659702483
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Ask_Me_Anything.mp3
 description: Eberhard beantwortet Fragen der Zuschauer:innen.
-thumbnail: folge130.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-15e9cd064d66ea890c754889ac&v=1659702483
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Ask_Me_Anything.mp3
+peertube: https://tube.tchncs.de/videos/embed/c192f0fe-f1d5-42f1-b684-38731fb26af5
 tags:
 - Q&A
+thumbnail: folge130.png
+title: Folge 130 - Ask Me Anything
+video: 6D_OgQ9A6CU
 ---
 
 Eberhard geht in dieser Folge auf Fragen aus dem Publikum

--- a/_posts/2022-08-26-folge131.md
+++ b/_posts/2022-08-26-folge131.md
@@ -1,15 +1,18 @@
 ---
-title: Episode 131 - Samir Talwar Longevity - live from SoCraTes Conference
-layout: folge
-video: udjF-G4zDCo
-peertube: https://tube.tchncs.de/videos/embed/cdda75f4-75d3-468e-acb0-eea172b8037d
+description: Samir Talwar discusses how a long lifespan of software can be suppoeted.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-ba0a311b31fc48f8b300bccdbd&v=1661628110
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Samir_Talwar_Longevity_-_live_from_SoCraTes_Conference.mp3
-description: Samir Talwar discusses how a long lifespan of software can be suppoeted. 
-thumbnail: folge131.png
+peertube: https://tube.tchncs.de/videos/embed/cdda75f4-75d3-468e-acb0-eea172b8037d
 tags:
 - English
 - Langlebigkeit
+thumbnail: folge131.png
+title: Episode 131 - Samir Talwar Longevity - live from SoCraTes Conference
+video: udjF-G4zDCo
 ---
 
 Successful software often has a long lifespan - sometimes even

--- a/_posts/2022-09-02-folge132.md
+++ b/_posts/2022-09-02-folge132.md
@@ -1,17 +1,20 @@
 ---
-title: Folge 132 - Der Self-contained-Systems-Architekturansatz
-layout: folge
-video: yVNQDZzqmh8
-peertube: https://tube.tchncs.de/videos/embed/49fde728-be7a-48cc-82d9-bb11244031ca
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-db3278a01d92e9dfbfd517538e&v=1662126431
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Der_Self-contained-Systems-Architekturansatz.mp3
 description: Was sind SCS (Self-contained Systems) und wann sind sie sinnvoll?
-thumbnail: folge132.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-db3278a01d92e9dfbfd517538e&v=1662126431
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Der_Self-contained-Systems-Architekturansatz.mp3
+peertube: https://tube.tchncs.de/videos/embed/49fde728-be7a-48cc-82d9-bb11244031ca
 tags:
 - Modularisierung
 - Microservices
 - Architekturstile
 - Frontend
+thumbnail: folge132.png
+title: Folge 132 - Der Self-contained-Systems-Architekturansatz
+video: yVNQDZzqmh8
 ---
 
 Self-contained Systems (SCS) teilen ein System in mehrere

--- a/_posts/2022-09-09-folge133.md
+++ b/_posts/2022-09-09-folge133.md
@@ -1,15 +1,18 @@
 ---
-title: Folge 133 - Wie Software-Architekt:innen ausbilden?
-layout: folge
-video: EvppM2WALJ0
-peertube: https://tube.tchncs.de/videos/embed/dfbf0af3-e024-4cba-ba3f-a14a8eec1ec0
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-a7dc4eaad58a814cc1d85b42cb&v=1662725423
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Wie_Software-Architektinnen_ausbilden.mp3
 description: Eberhard berichtet von verschiedenen Programmen zur Architekt:innen-Ausbildung
-thumbnail: folge133.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-a7dc4eaad58a814cc1d85b42cb&v=1662725423
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Wie_Software-Architektinnen_ausbilden.mp3
+peertube: https://tube.tchncs.de/videos/embed/dfbf0af3-e024-4cba-ba3f-a14a8eec1ec0
 tags:
 - Ausbildung
 - Rolle Software-Architektin
+thumbnail: folge133.png
+title: Folge 133 - Wie Software-Architekt:innen ausbilden?
+video: EvppM2WALJ0
 ---
 
 Für die Ausbildung von Architekt:innen gibt es viele unterschiedliche

--- a/_posts/2022-09-16-folge134.md
+++ b/_posts/2022-09-16-folge134.md
@@ -1,15 +1,20 @@
 ---
-title: Folge 134 - Domain Prototyping - Iterative Entwicklung mit Domain-driven Design & User Experience mit Tobias Goeschel
-layout: folge
-video: wdggcdnq7T4
-peertube: https://tube.tchncs.de/videos/embed/b6f90058-8c00-4be9-9c8e-d906f74f2616
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-9277a6959f1fdf596968beae1d&v=1663331993
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Domain_Prototyping.mp3
 description: Tobias Goeschel zeigt wie Domain Protoyping UX und DDD vereinigt.
-thumbnail: folge134.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-9277a6959f1fdf596968beae1d&v=1663331993
+guests:
+- Domain-driven Design & User Experience mit Tobias Goeschel
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Domain_Prototyping.mp3
+peertube: https://tube.tchncs.de/videos/embed/b6f90058-8c00-4be9-9c8e-d906f74f2616
 tags:
 - Domain-driven Design
 - UX
+thumbnail: folge134.png
+title: Folge 134 - Domain Prototyping - Iterative Entwicklung mit Domain-driven Design
+  & User Experience mit Tobias Goeschel
+video: wdggcdnq7T4
 ---
 
 Gutes Design von Software-Systemen benötigt - ähnlich wie gutes

--- a/_posts/2022-09-23-folge135.md
+++ b/_posts/2022-09-23-folge135.md
@@ -1,16 +1,20 @@
 ---
-title: Folge 135 - HTTP mit Lucas Dohmen
-layout: folge
-video: uZ4hcgZZNqY
-peertube: https://tube.tchncs.de/videos/embed/dce75161-3416-49e3-b730-bd135b7b8f52
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-47415df9642015835977eea92b&v=1663944517
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/HTTP.mp3
 description: Lucas Dohmen diskutiert das HTTP-Protokoll aus Architektur-Sicht
-thumbnail: folge135.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-47415df9642015835977eea92b&v=1663944517
+guests:
+- Lucas Dohmen
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/HTTP.mp3
+peertube: https://tube.tchncs.de/videos/embed/dce75161-3416-49e3-b730-bd135b7b8f52
 tags:
 - HTTP
 - REST
 - Frontend
+thumbnail: folge135.png
+title: Folge 135 - HTTP mit Lucas Dohmen
+video: uZ4hcgZZNqY
 ---
 
 Seit Anbeginn basiert das Web auf HTTP. Auf den ersten Blick wirkt

--- a/_posts/2022-09-30-folge136.md
+++ b/_posts/2022-09-30-folge136.md
@@ -1,16 +1,21 @@
 ---
-title: Episode 136 - Encouraging Engineering Excellence with Johannes Mainusch and Robert Albrecht
-layout: folge
-peertube: https://tube.tchncs.de/videos/embed/9fa65ac8-9eed-4848-b06d-54de10c5a707
-video: flGyqKRgpVA
+description: Johannes Mainusch, Robert Albrecht, and Eberhard Wolff engineering excellence
+  with a focus on feedback
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-bcdb7c0858cfae8522ae462e67&v=1664609631
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Encouraging_Engineering_Excellence_with_Johannes_Mainusch_and_Robert_Albrecht.mp3
-description: Johannes Mainusch, Robert Albrecht, and Eberhard Wolff engineering excellence with a focus on feedback 
-thumbnail: folge136.png
+peertube: https://tube.tchncs.de/videos/embed/9fa65ac8-9eed-4848-b06d-54de10c5a707
 tags:
 - English
 - Karriere
 - Engineering Excellence
+thumbnail: folge136.png
+title: Episode 136 - Encouraging Engineering Excellence with Johannes Mainusch and
+  Robert Albrecht
+video: flGyqKRgpVA
 ---
 
 Are you already a 10-star expert in Vue.js or Flutter or TypeScript,

--- a/_posts/2022-10-07-folge137.md
+++ b/_posts/2022-10-07-folge137.md
@@ -1,17 +1,21 @@
 ---
-title: Episode 137 - Non-linear Thinking with Diana Montalion
-layout: folge
-video: pOvbpuv5W1A
-peertube: https://tube.tchncs.de/videos/embed/5fceeafb-7430-4623-a584-115bdc10ee32
+description: Diana Montalion talks about non-liner thinking and its application to
+  software architecture.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-4e6a924bf0a7cde75c32f5285a&v=1665155207
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Non-linear_Thinking_with_Diana_Montalion.mp3
-description: Diana Montalion talks about non-liner thinking and its application to software architecture.
-thumbnail: folge137.png
+peertube: https://tube.tchncs.de/videos/embed/5fceeafb-7430-4623-a584-115bdc10ee32
 tags:
 - English
 - Nonlinear Thinking
 - Soziotechnische Systeme
 - Systems Thinking
+thumbnail: folge137.png
+title: Episode 137 - Non-linear Thinking with Diana Montalion
+video: pOvbpuv5W1A
 ---
 
 We are used to linear thinking - but really nonlinear thinking and

--- a/_posts/2022-10-14-folge138.md
+++ b/_posts/2022-10-14-folge138.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 138 - Was ist Documentation as Code? mit Falk Sippach
-layout: folge
-video: 7cIQfjDYK04
-peertube: https://tube.tchncs.de/videos/embed/a1b7bb8e-c56b-43c3-8c4e-a91ce4f160ad
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-e011dd5d00cbf17df4549170f1&v=1665754799
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Was_ist_Documentation_as_Code_mit_Falk_Sippach.mp3
 description: Falk Sippach spricht mit Lisa Schäfer über Documentation as Code
-thumbnail: folge138.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-e011dd5d00cbf17df4549170f1&v=1665754799
+guests:
+- Falk Sippach
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Was_ist_Documentation_as_Code_mit_Falk_Sippach.mp3
+peertube: https://tube.tchncs.de/videos/embed/a1b7bb8e-c56b-43c3-8c4e-a91ce4f160ad
 tags:
 - Dokumentation
+thumbnail: folge138.png
+title: Folge 138 - Was ist Documentation as Code? mit Falk Sippach
+video: 7cIQfjDYK04
 ---
   
 Falk Sippach wird beim Software Architecture Gathering den Vortrag

--- a/_posts/2022-10-21-folge139.md
+++ b/_posts/2022-10-21-folge139.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 139 - Christoph Iserlohn & Lisa Schäfer - Architektur und Security 
-layout: folge
-video: SA9TEltoedc
-peertube: https://tube.tchncs.de/videos/embed/ba0d46b4-88f4-43a3-999d-6119e269ae94
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-bebc2dc76cfff6451bc484f01a&v=1666367885
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Christoph_Iserlohn_und_Lisa_Moritz_Architektur_und_Security.mp3
 description: Christoph Iserlohn spricht mit Lisa Schäfer über Sicherheit aus Architektur-Sicht
-thumbnail: folge139.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-bebc2dc76cfff6451bc484f01a&v=1666367885
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Christoph_Iserlohn_und_Lisa_Moritz_Architektur_und_Security.mp3
+peertube: https://tube.tchncs.de/videos/embed/ba0d46b4-88f4-43a3-999d-6119e269ae94
 tags:
 - Sicherheit
+thumbnail: folge139.png
+title: Folge 139 - Christoph Iserlohn & Lisa Schäfer - Architektur und Security
+video: SA9TEltoedc
 ---
 
 

--- a/_posts/2022-10-28-folge140.md
+++ b/_posts/2022-10-28-folge140.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 140 - Zukunftssichere Architekturen - Keine gute Idee?
-layout: folge
-video: x1s0_QwGOMQ
-peertube: https://tube.tchncs.de/videos/embed/018ac786-4fde-473c-ae0e-f56952cdf72b
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-f827cc21a5c9e299ac5b41ec1e&v=1666965074
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Zukunftssichere_Architekturen_Keine_gute_Idee.mp3
 description: Warum sollte man eine Architektur nicht zukunftssicher anlegen?
-thumbnail: folge140.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-f827cc21a5c9e299ac5b41ec1e&v=1666965074
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Zukunftssichere_Architekturen_Keine_gute_Idee.mp3
+peertube: https://tube.tchncs.de/videos/embed/018ac786-4fde-473c-ae0e-f56952cdf72b
 tags:
 - Langlebigkeit
+thumbnail: folge140.png
+title: Folge 140 - Zukunftssichere Architekturen - Keine gute Idee?
+video: x1s0_QwGOMQ
 ---
 
 Architektur steht für das stabile, schwer zu ändernde. Also sollte

--- a/_posts/2022-11-04-folge141.md
+++ b/_posts/2022-11-04-folge141.md
@@ -1,16 +1,20 @@
 ---
-title: Folge 141 - Auftragstaktik - Agilität beim Militär? mit Sönke Marahrens
-layout: folge
-video: Oc4X7AZpJgA
-peertube: https://tube.tchncs.de/videos/embed/6b9fd03a-783c-42c9-bac1-a813c41470e7
+description: null
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-d955cb1f0ad4e4cba222056487&v=1667569089
+guests:
+- Sönke Marahrens
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Auftragstaktik_-_Agilitaet_beim_Militaer_mit_Soenke_Marahrens.mp3
-description: 
-thumbnail: folge141.png
+peertube: https://tube.tchncs.de/videos/embed/6b9fd03a-783c-42c9-bac1-a813c41470e7
 tags:
 - Auftragstaktik
 - Agilität
 - Organisation
+thumbnail: folge141.png
+title: Folge 141 - Auftragstaktik - Agilität beim Militär? mit Sönke Marahrens
+video: Oc4X7AZpJgA
 ---
 
 Auftragstaktik ist ein Konzept im Militär: Man gibt nur Ziele vor. Wie

--- a/_posts/2023-10-13-episode184.md
+++ b/_posts/2023-10-13-episode184.md
@@ -1,17 +1,21 @@
 ---
-title: Folge 184 - Bert Jan Schrijver about Generic or Specific?
-layout: folge
-video: eJlRttUDrog
-peertube: https://tube.tchncs.de/videos/embed/94fabfc9-3191-4e89-83f9-9968505e9d8d
+description: Bert Jan Schrijver discusses whether we should build generic or specific
+  solutions.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-dada9cc33e65f90c992dae675&v=1697221121
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Bert_Jan_Schrijver_Generic_or_Specific.mp3
-description: Bert Jan Schrijver discusses whether we should build generic or specific solutions.
-thumbnail: episode184.png
+peertube: https://tube.tchncs.de/videos/embed/94fabfc9-3191-4e89-83f9-9968505e9d8d
 tags:
 - English
 - Grundlagen
 - Live from Software Architecture Gathering
 - Wiederverwendung
+thumbnail: episode184.png
+title: Folge 184 - Bert Jan Schrijver about Generic or Specific?
+video: eJlRttUDrog
 ---
 
 Usually, this is not an easy question to answer. The answer depends on

--- a/_posts/2024-05-10-episode215.md
+++ b/_posts/2024-05-10-episode215.md
@@ -1,15 +1,19 @@
 ---
-title: Episode 215 - Alberto Brandolini - The Chasm Between Architecture and Business
-layout: folge
-video: n89L3I8P7uQ
-peertube: https://tube.tchncs.de/videos/embed/ca109b5b-221e-4458-9c97-0f3d7d10828a
+description: Alberto Brandolini discusses why architecture and business need to collaborate
+  so closely - and why
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-6205690fbc6033ebc0ce6715bb&v=1715345615
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Alberto_Brandolini_The_Chasm_Between_Architecture_and_Business.mp3
-description: Alberto Brandolini discusses why architecture and business need to collaborate so closely - and why
-thumbnail: episode215.png
+peertube: https://tube.tchncs.de/videos/embed/ca109b5b-221e-4458-9c97-0f3d7d10828a
 tags:
 - Domain-driven Design
 - English
+thumbnail: episode215.png
+title: Episode 215 - Alberto Brandolini - The Chasm Between Architecture and Business
+video: n89L3I8P7uQ
 ---
 
 Alberto Brandolini is the creator of Event Storming, a technique aimed


### PR DESCRIPTION
Add guest and moderator metadata for episodes 215, 184, 141-104.

Batch 25 - MASSIVE BATCH systematically filling major gaps in issue #60.
Processed 40 episode files in one comprehensive batch.

Notable guests extracted:
- Episode 141: Sönke Marahrens  
- Episode 138: Falk Sippach
- Episode 135: Lucas Dohmen
- Episode 134: Domain-driven Design & User Experience mit Tobias Goeschel
- Episode 128: Stefan Toth
- Episode 124: Stefan Toth
- Episode 122: Felix Müller
- Episode 114: Aminata Sidibe - Wir bauen eine Software-Architektur
- Episode 107: Marina Köhn, Jutta Eckstein, Max Schulze - live von der OOP!

Changes:
- Added 'guests' field with extracted guest names or empty arrays
- Added 'moderators' field with ["Eberhard Wolff"]
- Massive batch processing covering episodes 215, 184, and entire range 141-104
- Major gap filling for efficient #60 completion